### PR TITLE
feat: integrate api client and disable mocks

### DIFF
--- a/frontend/lib/app/constants.dart
+++ b/frontend/lib/app/constants.dart
@@ -1,6 +1,6 @@
 class AppConstants {
   // 백엔드 연동 전까지 모킹 사용 여부
-  static const bool useMockApi = true;
+  static const bool useMockApi = false;
 
   // 모킹 시 네트워크 지연 흉내(ms)
   static const int simulatedNetworkDelayMs = 500;

--- a/frontend/lib/services/album_api.dart
+++ b/frontend/lib/services/album_api.dart
@@ -3,18 +3,12 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 import 'package:frontend/app/constants.dart';
-import 'package:frontend/services/auth_service.dart';
+import 'api_client.dart';
 
 class AlbumApi {
-  static Uri _uri(String path) => Uri.parse('${AuthService.baseUrl}$path');
+  static Uri _uri(String path) => ApiClient.uri(path);
 
-  static Map<String, String> _headersJson() {
-    final token = AuthService.accessToken;
-    return {
-      'Content-Type': 'application/json',
-      if (token != null) 'Authorization': 'Bearer $token',
-    };
-  }
+  static Map<String, String> _headersJson() => ApiClient.headers();
 
   // GET /api/albums?sort=&page=&size=&favoriteOnly=
   static Future<Map<String, dynamic>> getAlbums({
@@ -69,8 +63,10 @@ class AlbumApi {
       'size': '$size',
       if (favoriteOnly != null) 'favoriteOnly': favoriteOnly.toString(),
     };
-    final uri = _uri('/api/albums').replace(queryParameters: q);
-    final res = await http.get(uri, headers: _headersJson());
+    final res = await ApiClient.get(
+      '/api/albums',
+      queryParameters: q,
+    );
     if (res.statusCode == 200) {
       return jsonDecode(res.body) as Map<String, dynamic>;
     }
@@ -103,15 +99,14 @@ class AlbumApi {
       };
     }
 
-    final res = await http.post(
-      _uri('/api/albums'),
-      headers: _headersJson(),
-      body: jsonEncode({
+    final res = await ApiClient.post(
+      '/api/albums',
+      body: {
         'title': title,
         if (description != null) 'description': description,
         if (coverPhotoId != null) 'coverPhotoId': coverPhotoId,
         if (photoIdList != null) 'photoIdList': photoIdList,
-      }),
+      },
     );
 
     if (res.statusCode == 201 || res.statusCode == 200) {
@@ -132,10 +127,9 @@ class AlbumApi {
       return;
     }
 
-    final res = await http.post(
-      _uri('/api/albums/$albumId/photos'),
-      headers: _headersJson(),
-      body: jsonEncode({'photoIdList': photoIds}),
+    final res = await ApiClient.post(
+      '/api/albums/$albumId/photos',
+      body: {'photoIdList': photoIds},
     );
 
     if (res.statusCode == 200 || res.statusCode == 204) return;
@@ -223,10 +217,7 @@ class AlbumApi {
         ],
       };
     }
-    final res = await http.get(
-      _uri('/api/albums/$albumId'),
-      headers: _headersJson(),
-    );
+    final res = await ApiClient.get('/api/albums/$albumId');
     if (res.statusCode == 200) {
       return jsonDecode(res.body) as Map<String, dynamic>;
     }

--- a/frontend/lib/services/api_client.dart
+++ b/frontend/lib/services/api_client.dart
@@ -1,0 +1,43 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'auth_service.dart';
+
+class ApiClient {
+  static Uri uri(String path, [Map<String, String>? query]) {
+    return Uri.parse('${AuthService.baseUrl}$path')
+        .replace(queryParameters: query);
+  }
+
+  static Map<String, String> headers({bool includeAuth = true, bool json = true}) {
+    final h = <String, String>{};
+    if (json) h['Content-Type'] = 'application/json';
+    if (includeAuth && AuthService.accessToken != null) {
+      h['Authorization'] = 'Bearer ${AuthService.accessToken}';
+    }
+    return h;
+  }
+
+  static Future<http.Response> get(
+    String path, {
+    Map<String, String>? queryParameters,
+    bool includeAuth = true,
+  }) {
+    return http.get(
+      uri(path, queryParameters),
+      headers: headers(includeAuth: includeAuth),
+    );
+  }
+
+  static Future<http.Response> post(
+    String path, {
+    Map<String, dynamic>? body,
+    bool includeAuth = true,
+  }) {
+    return http.post(
+      uri(path),
+      headers: headers(includeAuth: includeAuth),
+      body: body != null ? jsonEncode(body) : null,
+    );
+  }
+}
+

--- a/frontend/lib/services/photo_api.dart
+++ b/frontend/lib/services/photo_api.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:frontend/app/constants.dart';
-import 'auth_service.dart';
+import 'api_client.dart';
 
 class PhotoApi {
-  static Uri _u(String p) => Uri.parse('${AuthService.baseUrl}$p');
+  static Uri _u(String p) => ApiClient.uri(p);
 
   Future<List<Map<String, dynamic>>> getPhotos({
     bool? favorite,
@@ -24,10 +24,10 @@ class PhotoApi {
     if (page != null) qp['page'] = page.toString();
     if (size != null) qp['size'] = size.toString();
 
-    final uri = Uri.parse(
-      '${AuthService.baseUrl}/api/photos',
-    ).replace(queryParameters: qp.isEmpty ? null : qp);
-    final r = await http.get(uri, headers: _h());
+    final r = await ApiClient.get(
+      '/api/photos',
+      queryParameters: qp.isEmpty ? null : qp,
+    );
     if (r.statusCode == 200) {
       final body = jsonDecode(r.body);
       if (body is List) {
@@ -73,7 +73,7 @@ class PhotoApi {
         },
       };
     }
-    final r = await http.get(_u('/api/photos/$photoId'), headers: _h());
+    final r = await ApiClient.get('/api/photos/$photoId');
     if (r.statusCode == 200) return jsonDecode(r.body) as Map<String, dynamic>;
     if (r.statusCode == 403) {
       throw Exception('접근 권한이 없습니다. (403)');
@@ -154,10 +154,7 @@ class PhotoApi {
       // 모킹: 현재 상태의 반대값을 최종 상태로 반환
       return !currentFavorite;
     }
-    final r = await http.post(
-      _u('/api/photos/$photoId/favorite'),
-      headers: _h(),
-    );
+    final r = await ApiClient.post('/api/photos/$photoId/favorite');
     if (r.statusCode == 200) {
       final body = jsonDecode(r.body);
       // 사양: isFavorite 필드 사용
@@ -181,10 +178,6 @@ class PhotoApi {
   }
 
   Map<String, String> _h({bool json = false}) {
-    final h = <String, String>{
-      'Authorization': 'Bearer ${AuthService.accessToken ?? ''}',
-    };
-    if (json) h['Content-Type'] = 'application/json';
-    return h;
+    return ApiClient.headers(json: json);
   }
 }

--- a/frontend/lib/services/photo_upload_api.dart
+++ b/frontend/lib/services/photo_upload_api.dart
@@ -3,10 +3,10 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:http/http.dart' as http;
 import '../app/constants.dart';
-import 'auth_service.dart';
+import 'api_client.dart';
 
 class PhotoUploadApi {
-  static Uri _endpoint(String path) => Uri.parse('${AuthService.baseUrl}$path');
+  static Uri _endpoint(String path) => ApiClient.uri(path);
 
   /// 사진 업로드 (QR 기반). 모킹 모드 지원.
   Future<Map<String, dynamic>> uploadPhotoViaQr({
@@ -48,8 +48,7 @@ class PhotoUploadApi {
 
     final uri = _endpoint('/api/photos');
     final request = http.MultipartRequest('POST', uri);
-    request.headers['Authorization'] =
-        'Bearer ${AuthService.accessToken ?? ''}';
+    request.headers.addAll(ApiClient.headers(json: false));
     request.fields['qrCode'] = qrCode;
     request.fields['takenAt'] = takenAtIso;
     request.fields['location'] = location;


### PR DESCRIPTION
## Summary
- disable mock API usage and point frontend to deployed backend
- add ApiClient with shared GET/POST logic and auth headers
- refactor service layers to consume ApiClient

## Testing
- `flutter test` *(fails: command not found)*
- `curl -i https://nemo-backend.onrender.com/api/auth/login -d '{"email":"test@example.com","password":"1234"}' -H 'Content-Type: application/json'` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad90d17730832498168d7155b04182