### PR TITLE
feat: 인생네컷(Life4cut) QR 업로드 기능 정상화 – webQr → S3 직결 URL 파싱 로직 추가

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoExceptionHandler.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoExceptionHandler.java
@@ -6,13 +6,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
+import org.springframework.http.MediaType;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+
 @RestControllerAdvice(assignableTypes = PhotoController.class)
 public class PhotoExceptionHandler {
+    private static final MediaType JSON_UTF8 =
+            new MediaType("application", "json", StandardCharsets.UTF_8);
+
     @ExceptionHandler(InvalidQrException.class)
     public ResponseEntity<Map<String, Object>> handleInvalidQr(InvalidQrException e) {
         return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
@@ -33,6 +38,6 @@ public class PhotoExceptionHandler {
         Map<String, Object> body = new HashMap<>();
         body.put("timestamp", LocalDateTime.now());
         body.put("message", message);
-        return ResponseEntity.status(status).body(body);
+        return ResponseEntity.status(status).contentType(JSON_UTF8).body(body);
     }
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
@@ -11,13 +11,17 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
-
+import org.springframework.http.MediaType;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final MediaType JSON_UTF8 =
+            new MediaType("application", "json", StandardCharsets.UTF_8);
 
     private Map<String, Object> body(String code, String message) {
         return Map.of(
@@ -31,44 +35,44 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<Map<String, Object>> handleApi(ApiException ex) {
         ErrorCode code = ex.getErrorCode();
-        return ResponseEntity.status(code.getStatus()).body(body(code.getCode(), ex.getMessage()));
+        return ResponseEntity.status(code.getStatus()).contentType(JSON_UTF8).body(body(code.getCode(), ex.getMessage()));
     }
 
     // ===== 사진/QR 전용 (원인별 상태 분리) =====
     @ExceptionHandler(InvalidQrException.class)
     public ResponseEntity<Map<String, Object>> invalid(InvalidQrException ex) {
-        return ResponseEntity.status(ErrorCode.INVALID_QR.getStatus())
+        return ResponseEntity.status(ErrorCode.INVALID_QR.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.INVALID_QR.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(ExpiredQrException.class)
     public ResponseEntity<Map<String, Object>> expired(ExpiredQrException ex) {
-        return ResponseEntity.status(ErrorCode.EXPIRED_QR.getStatus())
+        return ResponseEntity.status(ErrorCode.EXPIRED_QR.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.EXPIRED_QR.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(DuplicateQrException.class)
     public ResponseEntity<Map<String, Object>> duplicate(DuplicateQrException ex) {
-        return ResponseEntity.status(ErrorCode.DUPLICATE_QR.getStatus())
+        return ResponseEntity.status(ErrorCode.DUPLICATE_QR.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.DUPLICATE_QR.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(NetworkFetchException.class)
     public ResponseEntity<Map<String, Object>> network(NetworkFetchException ex) {
-        return ResponseEntity.status(ErrorCode.NETWORK_FAILED.getStatus())
+        return ResponseEntity.status(ErrorCode.NETWORK_FAILED.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.NETWORK_FAILED.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(StorageException.class)
     public ResponseEntity<Map<String, Object>> storage(StorageException ex) {
-        return ResponseEntity.status(ErrorCode.STORAGE_FAILED.getStatus())
+        return ResponseEntity.status(ErrorCode.STORAGE_FAILED.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.STORAGE_FAILED.getCode(), ex.getMessage()));
     }
 
     // ===== 기타 표준화 =====
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> invalidParam(MethodArgumentNotValidException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(JSON_UTF8)
                 .body(body(ErrorCode.VALIDATION_FAILED.getCode(), "요청 파라미터가 잘못되었습니다."));
     }
 
@@ -78,39 +82,39 @@ public class GlobalExceptionHandler {
         HttpStatus status = (msg != null && (msg.contains("이미 가입된") || msg.contains("중복")))
                 ? HttpStatus.CONFLICT : HttpStatus.BAD_REQUEST;
         String code = (status == HttpStatus.CONFLICT) ? ErrorCode.CONFLICT.getCode() : ErrorCode.INVALID_REQUEST.getCode();
-        return ResponseEntity.status(status).body(body(code, msg));
+        return ResponseEntity.status(status).contentType(JSON_UTF8).body(body(code, msg));
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, Object>> constraint(DataIntegrityViolationException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
+        return ResponseEntity.status(HttpStatus.CONFLICT).contentType(JSON_UTF8)
                 .body(body("CONSTRAINT_VIOLATION", "중복 데이터로 처리할 수 없습니다."));
     }
 
     @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
     public ResponseEntity<Map<String, Object>> notAcceptable(HttpMediaTypeNotAcceptableException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
+        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).contentType(JSON_UTF8)
                 .body(body("NOT_ACCEPTABLE", "요청/응답의 미디어 타입이 맞지 않습니다."));
     }
 
     @ExceptionHandler(HttpClientErrorException.TooManyRequests.class)
     public ResponseEntity<Map<String, Object>> tooMany(HttpClientErrorException.TooManyRequests e) {
         log.warn("[EX-429→503] {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).contentType(JSON_UTF8)
                 .body(Map.of("code","NAVER_RATE_LIMIT","msg","잠시 후 자동 재시도 중입니다."));
     }
 
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<Map<String, Object>> http4xx(HttpClientErrorException e) {
         log.warn("[EX-4xx] {}", e.getMessage());
-        return ResponseEntity.status(e.getStatusCode())
+        return ResponseEntity.status(e.getStatusCode()).contentType(JSON_UTF8)
                 .body(Map.of("code","REMOTE_4XX","msg","요청이 올바른지 확인해주세요."));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> any(Exception ex) {
         log.error("[UNEXPECTED] {}", ex.getMessage(), ex);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(JSON_UTF8)
                 .body(body("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
     }
 }


### PR DESCRIPTION
📌 개요

인생네컷(Life4cut) QR을 스캔하여 서버로 업로드할 때, 기존 로직은 `download.life4cut.net/webQr` 페이지의 HTML 또는 webQrJson 안에서 이미지 URL을 추출하려고 했으나 **해당 페이지는 JS 기반 렌더링(SPA) 구조라 정적 HTML에 이미지 URL이 존재하지 않아 항상 실패함**.

이번 PR은 Life4cut QR이 제공하는 **쿼리 스트링(bucket + folderPath)** 를 직접 파싱하여 **S3 원본 이미지 URL을 구성하는 방식으로 변경**하여, 모든 인생네컷 QR을 안정적으로 처리하도록 개선함.

🐞 기존 문제점 (Before)

* 인생네컷 QR → `/webQr?...` 로 리다이렉트됨
* HTML은 실제 이미지 URL이 없음 (JS로 렌더링)
* webQrJson 역시 보호된 API 또는 CORS 차단으로 서버에서 접근 불가
* 따라서 이미지 URL을 찾지 못해 **항상 UPSTREAM_FAILED(502)** 발생

서버 로그 예시:

```
원격 자산 추출 실패: 이미지/영상 URL을 찾지 못했습니다.
```

QR 업로드 기능이 실사용 불가 상태였음.

🚀 변경 사항 (After)

🔥 핵심 변경

`resolveLife4cutNextUrl()` 로직을 완전히 재작성하여:

* `download.life4cut.net/webQr?...` URL에서
  **bucket=release-renewal-s3**
  **folderPath=/QRimage/...**
  값을 직접 추출
* Life4cut의 실제 사진 저장 위치가 **S3 고정 경로**인 점을 활용
* 이를 기반으로 **S3 직결 이미지 URL(image.jpg)** 을 직접 생성

✔ 예시

webQr URL:

```
https://download.life4cut.net/webQr?bucket=release-renewal-s3
  &folderPath=/QRimage/20251113/506/38049ea7-f747-4050-84af-8907bd734214
```

생성되는 S3 URL:

```
https://release-renewal-s3.s3.ap-northeast-2.amazonaws.com
/QRimage/20251113/506/38049ea7-f747-4050-84af-8907bd734214/image.jpg
```

서버는 이 URL을 이미지 응답으로 다운로드 → S3/LocalStack → `/files/...` 로 저장.

📡 전체 처리 흐름 (After)

1. QR 스캔 → `api.life4cut.net/{hash}`
2. redirect → `download.life4cut.net/webQr?...`
3. PR에서 추가한 로직이
   **bucket + folderPath → S3 image.jpg** 로 변환
4. 서버가 이미지 바이트를 직접 다운받아 저장
5. `/api/photos` 정상 업로드 완료

📈 실제 동작 로그 (성공 예시)

```
[QR][life4cut] webQr=... -> directS3=https://release-renewal-s3.s3.ap-northeast-2.amazonaws.com/QRimage/.../image.jpg
[QR][life4cut][forceJump] ... -> .../image.jpg
Hibernate insert into photos ...
[UPLOAD(QR)][status]=201
```

앱에서도 정상적으로 사진 표시됨.

🧪 테스트

* 실제 인생네컷 QR(여러 지점 날짜)로 테스트 완료
* 리다이렉트 및 파싱 정상 처리
* 중복 QR 업로드 차단도 정상 동작
* 이미지 저장 및 반환 URL 정상

🛠 향후 확장(옵션)

* 인생네컷 일부 QR은 `video.mp4` 포함 → `/video.mp4` 패턴도 지원 가능
* 다른 브랜드(하루필름/포토이즘 등)도 동일 패턴 확장 가능

✅ 결론

이 PR을 통해 인생네컷 QR 기반 업로드 기능이 **완전히 정상화**되었으며,
실제 사용자 경험 기준으로도 즉시 사용 가능한 안정적인 구현이 완료됨.
