### PR TITLE
앨범 공유 기능 추가 및 사진창 필터 레이아웃 개선 및 친구 요청 쿼리 파라미터

### DIFF
--- a/frontend/lib/presentation/screens/photo/photo_list_screen.dart
+++ b/frontend/lib/presentation/screens/photo/photo_list_screen.dart
@@ -54,88 +54,109 @@ class _PhotoListScreenState extends State<PhotoListScreen> {
             // 사진/앨범 전환 토글(정중앙 고정) + (앨범 모드) 새 앨범 버튼(우측 끝)
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: SizedBox(
-                height: 36,
-                child: Stack(
-                  alignment: Alignment.center,
-                  children: [
-                    if (!_showAlbums)
-                      Positioned(
-                        left: 0,
-                        child: _BrandFilter(
-                          value: _brand,
-                          onChanged: (v) {
-                            setState(() => _brand = v);
-                            context.read<PhotoProvider>().resetAndLoad(
-                              brand: v,
-                            );
-                          },
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  SizedBox(
+                    height: 40,
+                    child: Stack(
+                      alignment: Alignment.center,
+                      children: [
+                        Align(
+                          alignment: Alignment.centerLeft,
+                          child: !_showAlbums
+                              ? ConstrainedBox(
+                                  constraints: const BoxConstraints(
+                                    maxWidth: 70,
+                                  ),
+                                  child: _BrandFilter(
+                                    value: _brand,
+                                    onChanged: (v) {
+                                      setState(() => _brand = v);
+                                      context
+                                          .read<PhotoProvider>()
+                                          .resetAndLoad(brand: v);
+                                    },
+                                  ),
+                                )
+                              : const SizedBox(width: 40),
                         ),
-                      ),
-                    Center(
-                      child: _TopToggle(
-                        isAlbums: _showAlbums,
-                        onChanged: (isAlbums) =>
-                            setState(() => _showAlbums = isAlbums),
-                      ),
-                    ),
-                    if (_showAlbums)
-                      Positioned(
-                        right: 0,
-                        child: IconButton(
-                          icon: const Icon(Icons.add),
-                          tooltip: '새 앨범',
-                          padding: const EdgeInsets.all(6),
-                          constraints: const BoxConstraints(
-                            minWidth: 36,
-                            minHeight: 36,
+                        Align(
+                          alignment: Alignment.center,
+                          child: _TopToggle(
+                            isAlbums: _showAlbums,
+                            onChanged: (isAlbums) =>
+                                setState(() => _showAlbums = isAlbums),
                           ),
-                          onPressed: () async {
-                            // 1) 사진 먼저 선택
-                            final selected = await Navigator.push<List<int>>(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => const SelectAlbumPhotosScreen(),
-                              ),
-                            );
-                            if (!mounted) return;
-                            if (selected == null) return;
+                        ),
+                        Align(
+                          alignment: Alignment.centerRight,
+                          child: _showAlbums
+                              ? IconButton(
+                                  icon: const Icon(Icons.add),
+                                  tooltip: '새 앨범',
+                                  padding: const EdgeInsets.all(6),
+                                  constraints: const BoxConstraints(
+                                    minWidth: 36,
+                                    minHeight: 36,
+                                  ),
+                                  onPressed: () async {
+                                    final selected =
+                                        await Navigator.push<List<int>>(
+                                          context,
+                                          MaterialPageRoute(
+                                            builder: (_) =>
+                                                const SelectAlbumPhotosScreen(),
+                                          ),
+                                        );
+                                    if (!mounted) return;
+                                    if (selected == null) return;
 
-                            // 2) 제목/설명 입력
-                            final created = await Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (_) => CreateAlbumScreenInitial(
-                                  selectedPhotoIds: selected,
+                                    final created = await Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                        builder: (_) =>
+                                            CreateAlbumScreenInitial(
+                                              selectedPhotoIds: selected,
+                                            ),
+                                      ),
+                                    );
+                                    if (!mounted) return;
+                                    if (created != null) {
+                                      ScaffoldMessenger.of(
+                                        context,
+                                      ).showSnackBar(
+                                        const SnackBar(
+                                          content: Text('앨범이 생성되었습니다.'),
+                                        ),
+                                      );
+                                    }
+                                  },
+                                )
+                              : ConstrainedBox(
+                                  constraints: const BoxConstraints(
+                                    maxWidth: 30,
+                                  ),
+                                  child: _SortDropdown(
+                                    value: _sort,
+                                    onChanged: (v) {
+                                      if (v == null) return;
+                                      setState(() => _sort = v);
+                                      context
+                                          .read<PhotoProvider>()
+                                          .resetAndLoad(sort: v);
+                                    },
+                                  ),
                                 ),
-                              ),
-                            );
-                            if (!mounted) return;
-                            if (created != null) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('앨범이 생성되었습니다.')),
-                              );
-                            }
-                          },
                         ),
-                      ),
-                    if (!_showAlbums)
-                      Positioned(
-                        right: 0,
-                        child: _SortDropdown(
-                          value: _sort,
-                          onChanged: (v) {
-                            if (v == null) return;
-                            setState(() => _sort = v);
-                            context.read<PhotoProvider>().resetAndLoad(sort: v);
-                          },
-                        ),
-                      ),
-                  ],
-                ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 10),
+                ],
               ),
             ),
-            const SizedBox(height: 12),
+            const SizedBox(height: 16),
             Expanded(
               child: Padding(
                 padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
@@ -229,19 +250,19 @@ class _TopToggle extends StatelessWidget {
     return ToggleButtons(
       isSelected: [!isAlbums, isAlbums],
       onPressed: (idx) => onChanged(idx == 1),
-      borderRadius: BorderRadius.circular(20),
-      constraints: const BoxConstraints(minHeight: 36, minWidth: 88),
+      borderRadius: BorderRadius.circular(18),
+      constraints: const BoxConstraints(minHeight: 32, minWidth: 80),
       selectedColor: scheme.onPrimary,
       fillColor: scheme.primary,
       color: scheme.onSurface.withOpacity(0.8),
-      textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+      textStyle: const TextStyle(fontSize: 15, fontWeight: FontWeight.w600),
       children: const [
         Padding(
-          padding: EdgeInsets.symmetric(horizontal: 12),
+          padding: EdgeInsets.symmetric(horizontal: 10),
           child: Text('사진'),
         ),
         Padding(
-          padding: EdgeInsets.symmetric(horizontal: 12),
+          padding: EdgeInsets.symmetric(horizontal: 10),
           child: Text('앨범'),
         ),
       ],
@@ -311,30 +332,39 @@ class _BrandFilter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     const brands = <String?>[null, '인생네컷', '포토이즘', '포토그레이'];
+    final dropdownValue = brands.contains(value) ? value : null;
     return Container(
       height: 28,
       padding: const EdgeInsets.symmetric(horizontal: 6),
       decoration: BoxDecoration(
         color: AppColors.secondary,
         border: Border.all(color: AppColors.divider, width: 1),
-        borderRadius: BorderRadius.circular(6),
+        borderRadius: BorderRadius.circular(1),
       ),
-      child: Center(
-        child: PopupMenuButton<String?>(
-          padding: EdgeInsets.zero,
-          color: AppColors.secondary,
-          elevation: 2,
-          shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(6)),
-          onSelected: (v) => onChanged(v),
-          itemBuilder: (ctx) => brands
+      child: DropdownButtonHideUnderline(
+        child: DropdownButton<String?>(
+          value: dropdownValue,
+          isExpanded: true,
+          hint: const Text(
+            '🏷️',
+            style: TextStyle(fontSize: 14, color: AppColors.textPrimary),
+          ),
+          icon: const Icon(
+            Icons.arrow_drop_down,
+            size: 18,
+            color: AppColors.textPrimary,
+          ),
+          style: const TextStyle(fontSize: 14, color: AppColors.textPrimary),
+          onChanged: (selected) {
+            debugPrint('[BrandFilter] dropdown changed value=$selected');
+            onChanged(selected);
+          },
+          selectedItemBuilder: (ctx) => brands
               .map(
-                (b) => PopupMenuItem<String?>(
-                  value: b,
+                (_) => const Center(
                   child: Text(
-                    b ?? '전체',
-                    maxLines: 1,
-                    overflow: TextOverflow.ellipsis,
-                    style: const TextStyle(
+                    '🏷️',
+                    style: TextStyle(
                       fontSize: 14,
                       color: AppColors.textPrimary,
                     ),
@@ -342,16 +372,18 @@ class _BrandFilter extends StatelessWidget {
                 ),
               )
               .toList(),
-          child: const SizedBox(
-            height: 28,
-            child: Center(
-              child: Text(
-                '🏷️',
-                textAlign: TextAlign.center,
-                style: TextStyle(fontSize: 14, color: AppColors.textPrimary),
-              ),
-            ),
-          ),
+          items: brands
+              .map(
+                (b) => DropdownMenuItem<String?>(
+                  value: b,
+                  child: Text(
+                    b ?? '전체',
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              )
+              .toList(),
         ),
       ),
     );

--- a/frontend/lib/services/album_api.dart
+++ b/frontend/lib/services/album_api.dart
@@ -29,11 +29,13 @@ class AlbumApi {
         Duration(milliseconds: AppConstants.simulatedNetworkDelayMs),
       );
       // mock content: 6개 고정 더미에서 페이징
+      const names = ['인생네컷', '하루필름', '포토이즘', '포토그레이', '포토랩', '엑시트'];
       final mock = List.generate(6, (i) {
         final id = 20 - i;
+        final title = names[i % names.length];
         return {
           'albumId': id,
-          'title': i == 0 ? '2025 여름방학' : '더미 앨범 $id',
+          'title': title,
           'coverPhotoUrl': i % 2 == 0
               ? 'https://picsum.photos/seed/album$id/600/800'
               : null,

--- a/frontend/lib/services/friend_api.dart
+++ b/frontend/lib/services/friend_api.dart
@@ -103,7 +103,7 @@ class FriendApi {
     throw Exception('Failed to search friends (${res.statusCode})');
   }
 
-  // POST /api/friends { targetUserId }
+  // ✅ POST /api/friends?targetId= (백엔드 @RequestParam Long targetId 에 맞춤)
   static Future<Map<String, dynamic>> addFriend(int targetUserId) async {
     if (AppConstants.useMockApi) {
       await Future.delayed(
@@ -125,12 +125,21 @@ class FriendApi {
         },
       };
     }
-    final res = await http.post(
-      _uri('/api/friends'),
-      headers: _headers(),
-      body: jsonEncode({'targetUserId': targetUserId}),
+
+    // 🔹 쿼리 파라미터로 targetId 전달
+    final uri = _uri('/api/friends').replace(
+      queryParameters: {
+        'targetId': targetUserId.toString(),
+      },
     );
-    if (res.statusCode == 201) {
+
+    // 🔹 body 필요 없음 (백엔드는 @RequestParam만 사용)
+    final res = await http.post(
+      uri,
+      headers: _headers(),
+    );
+
+    if (res.statusCode == 200 || res.statusCode == 201) {
       return jsonDecode(res.body) as Map<String, dynamic>;
     }
     if (res.statusCode == 409) throw Exception('ALREADY_FRIEND');
@@ -139,7 +148,7 @@ class FriendApi {
     throw Exception('Failed to add friend (${res.statusCode})');
   }
 
-  // PUT /api/friends/accept { requesterUserId }
+  // ✅ PUT /api/friends/accept?requesterId= (백엔드 @RequestParam Long requesterId 에 맞춤)
   static Future<Map<String, dynamic>> acceptFriend(int requesterUserId) async {
     if (AppConstants.useMockApi) {
       await Future.delayed(
@@ -157,10 +166,17 @@ class FriendApi {
         },
       };
     }
+
+    final uri = _uri('/api/friends/accept').replace(
+      queryParameters: {
+        'requesterId': requesterUserId.toString(),
+      },
+    );
+
+    // 🔹 body 제거 (쿼리 파라미터만 전달)
     final res = await http.put(
-      _uri('/api/friends/accept'),
+      uri,
       headers: _headers(),
-      body: jsonEncode({'requesterUserId': requesterUserId}),
     );
     if (res.statusCode == 200) {
       return jsonDecode(res.body) as Map<String, dynamic>;


### PR DESCRIPTION
1. 앨범 공유 기능 추가
앨범 목록에서 앨범을 길게 눌렀을 때 공유 시트가 바로 표시되도록 구현
공유 시트 기능:
URL 생성/복사
현재 공유 대상 확인 및 제거
친구 검색 및 선택
참여자 추가
친구가 아닌 사용자도 친구 추가 후 공유 가능

2. 사진창 필터 레이아웃 조정
사진/앨범 토글 버튼을 화면 중앙에 고정
브랜드 필터(왼쪽)와 정렬 필터(오른쪽)를 토글 버튼 양옆에 배치
필터 너비 조정으로 텍스트 잘림 방지
수정된 파일
frontend/lib/presentation/screens/album/album_detail_screen.dart
사진 선택 시 체크 표시 UI 개선
선택 모드 성능 최적화
frontend/lib/presentation/screens/photo/photo_list_screen.dart
앨범 길게 눌렀을 때 공유 시트 표시 기능 추가
필터 레이아웃 조정 (브랜드 필터, 정렬 필터, 토글 버튼 위치)

테스트 사항
[ ] 앨범 목록에서 앨범을 길게 눌러 공유 시트가 표시되는지 확인
[ ] 공유 시트에서 URL 생성/복사가 정상 동작하는지 확인
[ ] 친구 선택 및 공유가 정상 동작하는지 확인
[ ] 사진/앨범 토글 버튼이 화면 중앙에 위치하는지 확인
[ ] 브랜드 필터와 정렬 필터가 토글 버튼 양옆에 올바르게 배치되는지 확인