### PR TITLE
feat(auth): API 명세에 맞게 공개/보호 엔드포인트 정리 및 JWT 필터 개선

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/auth/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/nemo/backend/domain/auth/jwt/JwtAuthenticationFilter.java
@@ -4,7 +4,8 @@ package com.nemo.backend.domain.auth.jwt;
 import com.nemo.backend.domain.auth.principal.UserPrincipal;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -17,7 +18,7 @@ import java.util.List;
 
 /**
  * 매 요청마다 Authorization 헤더를 검사해 유효한 경우 SecurityContext에 인증 주체(UserPrincipal)를 설정한다.
- * - 공개 경로(로그인/회원가입/Swagger/H2 등)는 필터를 건너뜀
+ * - 공개 경로(로그인/회원가입/이메일 인증/비밀번호 재설정/Swagger/H2 등)는 필터를 건너뜀
  * - 보호 경로에서 토큰이 없거나 잘못됐으면 401로 응답
  */
 @Slf4j
@@ -26,21 +27,35 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     private final JwtUtil jwtUtil;
     private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
-    // 🔓 이 경로들은 필터를 건너뜁니다 (공개)
+    // 🔓 이 경로들은 필터를 건너뜁니다 (공개, 토큰 필요 없음)
     private static final List<String> PUBLIC_PATTERNS = List.of(
+            // infra / 문서
             "/h2-console/**",
+            "/swagger-ui/**",
+            "/v3/api-docs/**",
+            "/files/**",
+            "/actuator/**",
+
+            // 회원 가입 / 로그인
             "/api/users/signup",
             "/api/users/login",
-            "/api/auth/dev/**",
-            "/swagger-ui/**",
-            "/v3/api-docs/**"
+
+            // 이메일 인증 (ex. /api/auth/email/verification/send, /confirm)
+            "/api/auth/email/**",
+
+            // 비밀번호 찾기 / 재설정 계열
+            "/api/auth/password/**",
+            "/api/users/password/**",
+
+            // 토큰 재발급 / 개발용 시드
+            "/api/auth/refresh",
+            "/api/auth/dev/**"
     );
 
-    // 🔒 이 경로들은 토큰이 반드시 필요합니다 (보호)
-    //  (SecurityConfig에서도 authenticated()로 맞춰주세요)
+    // 🔒 이 경로들은 토큰이 반드시 필요합니다 (보호 대상)
+    //  - PUBLIC_PATTERNS 에 포함된 것들은 예외
     private static final List<String> PROTECTED_PATTERNS = List.of(
-            "/api/friends/**"
-            // 필요시 여기에 추가
+            "/api/**"      // 전체 API 보호, 위의 PUBLIC 은 스킵
     );
 
     public JwtAuthenticationFilter(JwtUtil jwtUtil) {
@@ -48,18 +63,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     @Override
-    protected void doFilterInternal(HttpServletRequest req, HttpServletResponse res, FilterChain chain)
+    protected void doFilterInternal(HttpServletRequest req,
+                                    HttpServletResponse res,
+                                    FilterChain chain)
             throws ServletException, IOException {
 
         String uri = req.getRequestURI();
 
-        // 1) 공개 경로: 그냥 통과
+        // 1) 공개 경로: 토큰 검사 없이 바로 통과
         if (matchesAny(uri, PUBLIC_PATTERNS)) {
             chain.doFilter(req, res);
             return;
         }
 
-        // 2) 이미 인증된 경우(다른 필터가 넣었거나 이전 체인에서 처리): 통과
+        // 2) 이미 인증된 경우(다른 필터에서 넣었을 때): 그대로 통과
         if (SecurityContextHolder.getContext().getAuthentication() != null) {
             chain.doFilter(req, res);
             return;
@@ -67,17 +84,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         // 3) 보호 경로: 토큰 필수
         if (matchesAny(uri, PROTECTED_PATTERNS)) {
-            String auth = req.getHeader("Authorization");
-            if (!StringUtils.hasText(auth)) {
+            String authHeader = req.getHeader("Authorization");
+
+            if (!StringUtils.hasText(authHeader)) {
                 writeUnauthorized(res, "Authorization header is missing");
                 return;
             }
 
             try {
-                Long userId = jwtUtil.getUserId(auth);
-                String email = null; // 필요시 jwtUtil.getEmail(auth) 사용
-                var principal = new UserPrincipal(userId, email);
-                var authentication = new UsernamePasswordAuthenticationToken(principal, null, null);
+                Long userId = jwtUtil.getUserId(authHeader);
+                String email = null; // 필요하면 jwtUtil.getEmail(authHeader) 사용
+
+                UserPrincipal principal = new UserPrincipal(userId, email);
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(principal, null, null);
+
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             } catch (Exception e) {
                 log.debug("JWT parse/verify failed: {}", e.getMessage());
@@ -86,13 +107,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         }
 
-        // 4) 그 외 경로: 정책에 따라 허용(permitAll)이라면 통과
+        // 4) 그 외 경로: 추가 정책 없이 그대로 진행
         chain.doFilter(req, res);
     }
 
     private boolean matchesAny(String uri, List<String> patterns) {
         for (String p : patterns) {
-            if (pathMatcher.match(p, uri)) return true;
+            if (pathMatcher.match(p, uri)) {
+                return true;
+            }
         }
         return false;
     }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoExceptionHandler.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoExceptionHandler.java
@@ -6,13 +6,18 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
-
+import org.springframework.http.MediaType;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
+
 @RestControllerAdvice(assignableTypes = PhotoController.class)
 public class PhotoExceptionHandler {
+    private static final MediaType JSON_UTF8 =
+            new MediaType("application", "json", StandardCharsets.UTF_8);
+
     @ExceptionHandler(InvalidQrException.class)
     public ResponseEntity<Map<String, Object>> handleInvalidQr(InvalidQrException e) {
         return buildResponse(HttpStatus.BAD_REQUEST, e.getMessage());
@@ -33,6 +38,6 @@ public class PhotoExceptionHandler {
         Map<String, Object> body = new HashMap<>();
         body.put("timestamp", LocalDateTime.now());
         body.put("message", message);
-        return ResponseEntity.status(status).body(body);
+        return ResponseEntity.status(status).contentType(JSON_UTF8).body(body);
     }
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
@@ -11,13 +11,17 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.client.HttpClientErrorException;
-
+import org.springframework.http.MediaType;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.Map;
 
 @Slf4j
 @RestControllerAdvice
 public class GlobalExceptionHandler {
+
+    private static final MediaType JSON_UTF8 =
+            new MediaType("application", "json", StandardCharsets.UTF_8);
 
     private Map<String, Object> body(String code, String message) {
         return Map.of(
@@ -31,44 +35,44 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ApiException.class)
     public ResponseEntity<Map<String, Object>> handleApi(ApiException ex) {
         ErrorCode code = ex.getErrorCode();
-        return ResponseEntity.status(code.getStatus()).body(body(code.getCode(), ex.getMessage()));
+        return ResponseEntity.status(code.getStatus()).contentType(JSON_UTF8).body(body(code.getCode(), ex.getMessage()));
     }
 
     // ===== 사진/QR 전용 (원인별 상태 분리) =====
     @ExceptionHandler(InvalidQrException.class)
     public ResponseEntity<Map<String, Object>> invalid(InvalidQrException ex) {
-        return ResponseEntity.status(ErrorCode.INVALID_QR.getStatus())
+        return ResponseEntity.status(ErrorCode.INVALID_QR.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.INVALID_QR.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(ExpiredQrException.class)
     public ResponseEntity<Map<String, Object>> expired(ExpiredQrException ex) {
-        return ResponseEntity.status(ErrorCode.EXPIRED_QR.getStatus())
+        return ResponseEntity.status(ErrorCode.EXPIRED_QR.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.EXPIRED_QR.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(DuplicateQrException.class)
     public ResponseEntity<Map<String, Object>> duplicate(DuplicateQrException ex) {
-        return ResponseEntity.status(ErrorCode.DUPLICATE_QR.getStatus())
+        return ResponseEntity.status(ErrorCode.DUPLICATE_QR.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.DUPLICATE_QR.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(NetworkFetchException.class)
     public ResponseEntity<Map<String, Object>> network(NetworkFetchException ex) {
-        return ResponseEntity.status(ErrorCode.NETWORK_FAILED.getStatus())
+        return ResponseEntity.status(ErrorCode.NETWORK_FAILED.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.NETWORK_FAILED.getCode(), ex.getMessage()));
     }
 
     @ExceptionHandler(StorageException.class)
     public ResponseEntity<Map<String, Object>> storage(StorageException ex) {
-        return ResponseEntity.status(ErrorCode.STORAGE_FAILED.getStatus())
+        return ResponseEntity.status(ErrorCode.STORAGE_FAILED.getStatus()).contentType(JSON_UTF8)
                 .body(body(ErrorCode.STORAGE_FAILED.getCode(), ex.getMessage()));
     }
 
     // ===== 기타 표준화 =====
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<Map<String, Object>> invalidParam(MethodArgumentNotValidException ex) {
-        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).contentType(JSON_UTF8)
                 .body(body(ErrorCode.VALIDATION_FAILED.getCode(), "요청 파라미터가 잘못되었습니다."));
     }
 
@@ -78,39 +82,39 @@ public class GlobalExceptionHandler {
         HttpStatus status = (msg != null && (msg.contains("이미 가입된") || msg.contains("중복")))
                 ? HttpStatus.CONFLICT : HttpStatus.BAD_REQUEST;
         String code = (status == HttpStatus.CONFLICT) ? ErrorCode.CONFLICT.getCode() : ErrorCode.INVALID_REQUEST.getCode();
-        return ResponseEntity.status(status).body(body(code, msg));
+        return ResponseEntity.status(status).contentType(JSON_UTF8).body(body(code, msg));
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
     public ResponseEntity<Map<String, Object>> constraint(DataIntegrityViolationException ex) {
-        return ResponseEntity.status(HttpStatus.CONFLICT)
+        return ResponseEntity.status(HttpStatus.CONFLICT).contentType(JSON_UTF8)
                 .body(body("CONSTRAINT_VIOLATION", "중복 데이터로 처리할 수 없습니다."));
     }
 
     @ExceptionHandler(HttpMediaTypeNotAcceptableException.class)
     public ResponseEntity<Map<String, Object>> notAcceptable(HttpMediaTypeNotAcceptableException ex) {
-        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE)
+        return ResponseEntity.status(HttpStatus.NOT_ACCEPTABLE).contentType(JSON_UTF8)
                 .body(body("NOT_ACCEPTABLE", "요청/응답의 미디어 타입이 맞지 않습니다."));
     }
 
     @ExceptionHandler(HttpClientErrorException.TooManyRequests.class)
     public ResponseEntity<Map<String, Object>> tooMany(HttpClientErrorException.TooManyRequests e) {
         log.warn("[EX-429→503] {}", e.getMessage());
-        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE)
+        return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).contentType(JSON_UTF8)
                 .body(Map.of("code","NAVER_RATE_LIMIT","msg","잠시 후 자동 재시도 중입니다."));
     }
 
     @ExceptionHandler(HttpClientErrorException.class)
     public ResponseEntity<Map<String, Object>> http4xx(HttpClientErrorException e) {
         log.warn("[EX-4xx] {}", e.getMessage());
-        return ResponseEntity.status(e.getStatusCode())
+        return ResponseEntity.status(e.getStatusCode()).contentType(JSON_UTF8)
                 .body(Map.of("code","REMOTE_4XX","msg","요청이 올바른지 확인해주세요."));
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> any(Exception ex) {
         log.error("[UNEXPECTED] {}", ex.getMessage(), ex);
-        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(JSON_UTF8)
                 .body(body("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
     }
 }

--- a/backend/src/main/java/com/nemo/backend/global/security/SecurityConfig.java
+++ b/backend/src/main/java/com/nemo/backend/global/security/SecurityConfig.java
@@ -1,3 +1,4 @@
+// backend/src/main/java/com/nemo/backend/global/security/SecurityConfig.java
 package com.nemo.backend.global.security;
 
 import com.nemo.backend.domain.auth.jwt.JwtAuthenticationFilter;
@@ -12,49 +13,58 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 
 /**
  * ✅ 스프링 시큐리티 설정
- * - 공개 경로: H2 콘솔, 회원가입/로그인, Swagger 문서
- * - 인증 필요: /api/friends/** (그리고 추후 보호가 필요한 API들)
- * - 매 요청마다 JWT 필터로 토큰을 검사하고, 성공 시 SecurityContext에 UserPrincipal 저장
+ * - 공개 경로: H2 콘솔, Swagger, 파일, 헬스체크, 회원가입/로그인, 이메일 인증, 비밀번호 재설정, 토큰 재발급, dev 시드
+ * - 인증 필요: 그 외 /api/** 전체 (ex. /api/users/me, /api/photos, /api/albums, /api/friends ...)
+ * - 매 요청마다 JWT 필터로 토큰을 검증하고, 성공 시 SecurityContext에 UserPrincipal 저장
  */
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtUtil jwtUtil; // 🔸 JwtAuthenticationFilter에 주입할 유틸
+    private final JwtUtil jwtUtil;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
         http
                 // 세션을 쓰지 않는 완전한 Stateless API 서버 모드
-                .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
                 // 권한 규칙
                 .authorizeHttpRequests(auth -> auth
-                        // 🔓 공개 허용
+                        // 🔓 토큰 없이 접근 가능한 공개 엔드포인트
                         .requestMatchers(
                                 "/h2-console/**",
-                                "/api/users/signup",
-                                "/api/users/login",
-                                "/api/auth/refresh",
-                                "/api/auth/dev/**",
-                                "/api/users/login",
                                 "/swagger-ui/**",
                                 "/v3/api-docs/**",
-                                "/api/auth/dev/**",
                                 "/files/**",
-                                "/actuator/**"
+                                "/actuator/**",
+
+                                "/api/users/signup",
+                                "/api/users/login",
+
+                                // 이메일 인증
+                                "/api/auth/email/**",
+
+                                // 비밀번호 찾기 / 재설정
+                                "/api/auth/password/**",
+                                "/api/users/password/**",
+
+                                // 토큰 재발급 및 dev 시드
+                                "/api/auth/refresh",
+                                "/api/auth/dev/**"
                         ).permitAll()
 
-                        // 🔒 친구 API는 인증 필요(토큰 필수) — 필요 시 여기에 보호 경로 추가
-                        .requestMatchers("/api/friends/**").authenticated()
+                        // 🔒 그 외 모든 /api/** 는 인증 필요
+                        .requestMatchers("/api/**").authenticated()
 
-                        // 나머지는 상황에 맞게: 우선은 허용(필요해지면 authenticated로 변경)
+                        // 그 밖의 정적 리소스 등은 일단 허용
                         .anyRequest().permitAll()
                 )
 
-                // CSRF/CORS/H2 콘솔 프레임
+                // CSRF 비활성화 + H2 콘솔을 위한 frameOptions 해제
                 .csrf(csrf -> csrf.disable())
-                .headers(h -> h.frameOptions(f -> f.disable()));
+                .headers(headers -> headers.frameOptions(frame -> frame.disable()));
 
         // 🔗 JWT 필터 등록: UsernamePasswordAuthenticationFilter 앞에서 토큰 검증
         http.addFilterBefore(new JwtAuthenticationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);


### PR DESCRIPTION
이 PR은 따로 설정할 생각이 있으면 머지하지 말고 없애도 됨

## 변경 내용

1. SecurityConfig 정리
   - API 명세서 기준으로 공개 엔드포인트를 명시적으로 permitAll 처리
     - /api/users/signup, /api/users/login
     - /api/auth/email/** (이메일 인증 메일 발송/확인)
     - /api/auth/password/**, /api/users/password/** (비밀번호 찾기/재설정)
     - /api/auth/refresh, /api/auth/dev/**
     - H2 콘솔, Swagger, 파일, actuator 등 인프라용 엔드포인트
   - 그 외 모든 `/api/**` 요청은 authenticated 로 통일
     - /api/users/me, /api/photos/**, /api/albums/**, /api/friends/** 등이 JWT 필수

2. JwtAuthenticationFilter 개선
   - PUBLIC_PATTERNS 에 위 공개 엔드포인트 전체를 등록해 필터를 스킵하도록 처리
   - PROTECTED_PATTERNS 를 `/api/**` 로 잡아서,
     - PUBLIC 이 아닌 모든 API 요청에서 Authorization 헤더를 검사하고
     - 유효한 JWT 이면 SecurityContext 에 `UserPrincipal` 세팅
     - 헤더가 없거나 파싱 실패 시 401 + JSON 응답(`{"error":"UNAUTHORIZED", ...}`) 반환
   - 이렇게 해서
     - 회원가입/로그인/이메일 인증/비밀번호 재설정은 토큰 없이 정상 동작
     - /api/users/me, /api/photos, /api/albums 등 마이페이지·사진·앨범 API 는 로그인한 사용자만 접근 가능

## 기대 효과

- API 명세서에 맞게 "로그인 전/후" 권한 경계가 명확해짐
- 기존에 `/api/users/me` 호출 시 403/Authorization header is missing 같은 문제가 나던 부분을 해결
- 이메일 인증, 비밀번호 재설정 API 들이 JWT 필터에 막히지 않고 정상적으로 호출 가능
- 이후 신규 보호 API 추가 시 `/api/**` 규칙에 자동으로 포함되어 일관된 보안 정책 유지
