### PR TITLE
앨범 썸네일 자동 생성 기능 추가 및 연관관계 동기화 개선

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -8,25 +8,17 @@ import com.nemo.backend.domain.album.service.AlbumService;
 import com.nemo.backend.domain.auth.util.AuthExtractor;  // 🔥 공통 인증 유틸
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/albums")
 @RequiredArgsConstructor // ⭐ 생성자 자동 생성 (final 필드만)
 public class AlbumController {
 
-    // --------------------------------------------------------
-    // ⭐ 의존성 주입
-    // --------------------------------------------------------
     private final AlbumService albumService;
-
-    /**
-     * 🔐 AuthExtractor
-     * - Authorization 헤더에서 userId를 뽑는 공통 로직
-     *   (JWT 검증 + RefreshToken 존재 여부까지 포함)
-     * - UserAuthController, PhotoController 등과 동일하게 사용
-     */
     private final AuthExtractor authExtractor;
 
     // ========================================================
@@ -40,7 +32,6 @@ public class AlbumController {
 
         List<AlbumSummaryResponse> content = albumService.getAlbums(userId);
 
-        // 간단한 페이징 형식으로 감싸서 반환
         return ResponseEntity.ok(
                 java.util.Map.of(
                         "content", content,
@@ -132,5 +123,31 @@ public class AlbumController {
         Long userId = authExtractor.extractUserId(authorizationHeader);
         albumService.deleteAlbum(userId, albumId);
         return ResponseEntity.noContent().build();
+    }
+
+    // ========================================================
+    // 8) POST /api/albums/{albumId}/thumbnail : 썸네일 생성/지정
+    // ========================================================
+    @PostMapping(
+            value = "/{albumId}/thumbnail",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<AlbumThumbnailResponse> updateThumbnail(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @PathVariable Long albumId,
+
+            // 예시 1: 앨범 내 사진 선택 (JSON Part, e.g. {"photoId": 125})
+            @RequestPart(value = "photoId", required = false) Long photoId,
+
+            // 예시 2: 직접 업로드 (Multipart file)
+            @RequestPart(value = "file", required = false) MultipartFile file
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+
+        AlbumThumbnailResponse resp =
+                albumService.updateThumbnail(userId, albumId, photoId, file);
+
+        return ResponseEntity.ok(resp);
     }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumThumbnailResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumThumbnailResponse.java
@@ -1,0 +1,19 @@
+// backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumThumbnailResponse.java
+package com.nemo.backend.domain.album.dto;
+
+public class AlbumThumbnailResponse {
+
+    private Long albumId;
+    private String thumbnailUrl;
+    private String message;
+
+    public AlbumThumbnailResponse(Long albumId, String thumbnailUrl, String message) {
+        this.albumId = albumId;
+        this.thumbnailUrl = thumbnailUrl;
+        this.message = message;
+    }
+
+    public Long getAlbumId() { return albumId; }
+    public String getThumbnailUrl() { return thumbnailUrl; }
+    public String getMessage() { return message; }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/entity/Album.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/entity/Album.java
@@ -23,6 +23,10 @@ public class Album extends BaseEntity {
 
     private String description;
 
+    // ✅ 앨범 썸네일 URL (명세의 coverPhotoUrl)
+    @Column(name = "cover_photo_url")
+    private String coverPhotoUrl;
+
     // 소유자 (User)
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)

--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -6,13 +6,18 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    // QR 중복 체크
     Optional<Photo> findByQrHash(String qrHash);
 
-    // 사용자별 목록 (삭제되지 않은 것만), 최신순
     Page<Photo> findByUserIdAndDeletedIsFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
+    // ✅ 앨범 내 사진들 (삭제 안 된 것만) 최신순
+    List<Photo> findByAlbum_IdAndDeletedIsFalseOrderByCreatedAtDesc(Long albumId);
+
+    // ✅ 특정 사진이 살아있는지 검사할 때 사용
+    Optional<Photo> findByIdAndDeletedIsFalse(Long id);
 }


### PR DESCRIPTION
🚀 개요

앨범 생성 시 또는 사진 추가 시, 가장 최근 업로드된 사진을 자동으로 앨범 썸네일(coverPhotoUrl)로 설정하는 기능을 추가했습니다.
또한 기존에 발생하던 **photoIds로 앨범에 사진을 연결해도 album.getPhotos()가 즉시 반영되지 않는 문제(JPA 역방향 미동기화)**를 해결했습니다.

이를 통해 앨범 생성 직후 자동 썸네일이 정확하게 반영되고,
앨범 목록/상세 조회에서도 사진 수 및 썸네일이 정상 표시됩니다.

✨ 주요 변경 사항
1) 자동 썸네일 생성 기능 구현

앨범 생성 시 photoIds에 연결된 사진들 중 가장 최신 생성일(createdAt) 기준으로 자동 선택

사진 추가 API에서도 앨범의 coverPhotoUrl이 비어 있을 경우 자동 지정

2) 사진 리스트 동기화 문제 해결

기존에는 p.setAlbum(saved)만 수행하여 FK만 업데이트되고
앨범 엔티티 내부의 photoList는 비어 있는 문제가 발생함

아래 로직을 추가하여 즉시 인식되도록 처리:

saved.setPhotos(photos);

3) 절대 경로 URL 규칙 통일

모든 사진/썸네일 URL을 다음 규칙으로 일원화함:

{public-base-url}/files/{s3Key}


Local: http://10.0.2.2:8080/files/...

향후 Prod: CDN 또는 S3 퍼블릭 URL로 변경 가능

4) AlbumService URL 처리 로직 통합

PhotoServiceImpl과 동일한 toPublicUrl 방식으로 통일

환경별 public-base-url 사용 가능하도록 개선

🧪 테스트
✔ 단일 사진 앨범 생성

photoIds: [1]

coverPhotoUrl = photoId 1의 imageUrl
→ 정상 작동

✔ 여러 장 연결된 앨범 생성

photoIds: [1, 2]

createdAt 비교 후 photoId 2가 최신 → coverPhotoUrl = photoId 2
→ 자동 최신 선택 정상

✔ photoIds 없이 생성

photoCount = 0, coverPhotoUrl = null
→ 설계대로 동작

⚠ 운영 배포 시 고려사항

public-base-url은 dev에서 10.0.2.2 사용하지만 운영에서는 HTTPS API 도메인 또는 CDN 도메인 사용 필요

/files/** 로 이미지 스트리밍은 로컬용이므로 운영에서는 S3 또는 CloudFront로 직접 서빙해야 함

썸네일 변경 시 CDN 캐시 무효화 정책 필요

외부 QR 경로 구조 변경 시 자동 썸네일 로직 영향 가능

📁 변경 파일 (요약)

AlbumService

toPublicUrl 통일

photoList 즉시 반영

자동 썸네일 로직 추가 (autoSetThumbnailIfMissing / pickAutoThumbnailUrl)

PhotoServiceImpl

public-base-url 로직 정리

기타 DTO 및 응답 구조 보강

✅ 결과

이 PR로 앨범 썸네일 관련 기능이 완전히 안정화되었으며,
QR 업로드 / 일반 업로드 / 수동 썸네일 업로드 모두 동일 규칙에서 정상 동작함.