### PR TITLE
feat: 프로필 업데이트 및 앨범 공유 도메인 리팩터링

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -15,7 +15,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 @RestController
-@RequestMapping("/api/albums")
+@RequestMapping(value ="/api/albums",
+        produces = "application/json; charset=UTF-8")
 @RequiredArgsConstructor // ⭐ 생성자 자동 생성 (final 필드만)
 public class AlbumController {
 

--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumShareController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumShareController.java
@@ -22,7 +22,8 @@ public class AlbumShareController {
     private final AlbumShareService albumShareService;
     private final AuthExtractor authExtractor;
 
-    // 🔹 공유 요청 보내기
+    // 🔹 앨범 공유 요청 보내기
+    // POST /api/albums/{albumId}/share
     @PostMapping("/{albumId}/share")
     public ResponseEntity<AlbumShareResponse> shareAlbum(
             @RequestHeader("Authorization") String authorizationHeader,
@@ -34,9 +35,10 @@ public class AlbumShareController {
         return ResponseEntity.ok(resp);
     }
 
-    // 🔹 특정 앨범의 공유 대상 목록 조회
-    @GetMapping("/{albumId}/share/targets")
-    public ResponseEntity<AlbumShareTargetsResponse> getShareTargets(
+    // 🔹 공유 멤버 목록 조회 (신 명세)
+    // GET /api/albums/{albumId}/share/members
+    @GetMapping("/{albumId}/share/members")
+    public ResponseEntity<AlbumShareTargetsResponse> getShareMembers(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long albumId
     ) {
@@ -45,34 +47,42 @@ public class AlbumShareController {
         return ResponseEntity.ok(resp);
     }
 
-    // 🔹 공유 대상 권한(Role) 변경
-    @PutMapping("/{albumId}/share/{shareId}/role")
-    public ResponseEntity<Void> updateShareRole(
+    // 🔹 공유 멤버 권한 변경 (신 명세: targetUserId 기반)
+    // PUT /api/albums/{albumId}/share/permission
+    @PutMapping("/{albumId}/share/permission")
+    public ResponseEntity<Void> updateSharePermission(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long albumId,
-            @PathVariable Long shareId,
-            @RequestParam("role") AlbumShare.Role role
+            @RequestBody UpdateSharePermissionRequest request
     ) {
         Long meId = authExtractor.extractUserId(authorizationHeader);
-        albumShareService.updateShareRole(albumId, shareId, meId, role);
-        return ResponseEntity.noContent().build();
+        albumShareService.updateShareRoleByUserId(
+                albumId,
+                request.targetUserId(),
+                meId,
+                request.role()
+        );
+        // 명세서는 200 OK 예시라 OK로 응답
+        return ResponseEntity.ok().build();
     }
 
     // 🔹 공유 해제 (OWNER가 강퇴 or 본인이 나가기)
-    @DeleteMapping("/{albumId}/share/{userId}")
+    // DELETE /api/albums/{albumId}/share/{targetUserId}
+    @DeleteMapping("/{albumId}/share/{targetUserId}")
     public ResponseEntity<Void> unshare(
             @RequestHeader("Authorization") String authorizationHeader,
             @PathVariable Long albumId,
-            @PathVariable Long userId
+            @PathVariable("targetUserId") Long targetUserId
     ) {
         Long meId = authExtractor.extractUserId(authorizationHeader);
-        albumShareService.unshare(albumId, userId, meId);
+        albumShareService.unshare(albumId, targetUserId, meId);
         return ResponseEntity.noContent().build();
     }
 
-    // 🔹 내가 "대기 중(PENDING)"인 공유 요청 목록
-    @GetMapping("/shared/pending")
-    public ResponseEntity<List<PendingShareResponse>> getPendingShares(
+    // 🔹 공유 요청 목록 조회 (신 명세)
+    // GET /api/albums/share/requests
+    @GetMapping("/share/requests")
+    public ResponseEntity<List<PendingShareResponse>> getShareRequests(
             @RequestHeader("Authorization") String authorizationHeader
     ) {
         Long meId = authExtractor.extractUserId(authorizationHeader);
@@ -80,39 +90,33 @@ public class AlbumShareController {
         return ResponseEntity.ok(list);
     }
 
-    // 🔹 공유 요청 수락
-    @PostMapping("/shared/{shareId}/accept")
-    public ResponseEntity<Void> acceptShare(
+    // 🔹 공유 요청 수락 (신 명세: albumId 기반)
+    // POST /api/albums/{albumId}/share/accept
+    @PostMapping("/{albumId}/share/accept")
+    public ResponseEntity<Void> acceptShareByAlbum(
             @RequestHeader("Authorization") String authorizationHeader,
-            @PathVariable Long shareId
+            @PathVariable Long albumId
     ) {
         Long meId = authExtractor.extractUserId(authorizationHeader);
-        albumShareService.acceptShare(shareId, meId);
-        return ResponseEntity.noContent().build();
+        albumShareService.acceptShareByAlbum(albumId, meId);
+        // 명세 예시는 200 OK
+        return ResponseEntity.ok().build();
     }
 
-    // 🔹 공유 요청 거절
-    @PostMapping("/shared/{shareId}/reject")
-    public ResponseEntity<Void> rejectShare(
+    // 🔹 공유 요청 거절 (신 명세: albumId 기반)
+    // POST /api/albums/{albumId}/share/reject
+    @PostMapping("/{albumId}/share/reject")
+    public ResponseEntity<Void> rejectShareByAlbum(
             @RequestHeader("Authorization") String authorizationHeader,
-            @PathVariable Long shareId
+            @PathVariable Long albumId
     ) {
         Long meId = authExtractor.extractUserId(authorizationHeader);
-        albumShareService.rejectShare(shareId, meId);
-        return ResponseEntity.noContent().build();
+        albumShareService.rejectShareByAlbum(albumId, meId);
+        return ResponseEntity.ok().build();
     }
 
-    // 🔹 내가 공유받은 앨범 목록
-    @GetMapping("/shared/me")
-    public ResponseEntity<List<SharedAlbumSummaryResponse>> getMySharedAlbums(
-            @RequestHeader("Authorization") String authorizationHeader
-    ) {
-        Long meId = authExtractor.extractUserId(authorizationHeader);
-        List<SharedAlbumSummaryResponse> list = albumShareService.getMySharedAlbums(meId);
-        return ResponseEntity.ok(list);
-    }
-
-    // 🔹 공유 링크 생성
+    // 🔹 공유 링크 생성 (명세 참고용 / 실제 배포 시 토큰 기반 링크로 개선 필요)
+    // POST /api/albums/{albumId}/share/link
     @PostMapping("/{albumId}/share/link")
     public ResponseEntity<AlbumShareLinkResponse> createShareLink(
             @RequestHeader("Authorization") String authorizationHeader,

--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumShareController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumShareController.java
@@ -16,7 +16,8 @@ import java.util.List;
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/albums")
+@RequestMapping(value ="/api/albums",
+        produces = "application/json; charset=UTF-8")
 public class AlbumShareController {
 
     private final AlbumShareService albumShareService;
@@ -125,5 +126,16 @@ public class AlbumShareController {
         Long meId = authExtractor.extractUserId(authorizationHeader);
         AlbumShareLinkResponse resp = albumShareService.createShareLink(albumId, meId);
         return ResponseEntity.ok(resp);
+    }
+
+    // 🔹 내가 공유받은 앨범 목록
+    // GET /api/albums/shared
+    @GetMapping("/shared")
+    public ResponseEntity<List<SharedAlbumSummaryResponse>> getMySharedAlbums(
+            @RequestHeader("Authorization") String authorizationHeader
+    ) {
+        Long meId = authExtractor.extractUserId(authorizationHeader);
+        List<SharedAlbumSummaryResponse> list = albumShareService.getMySharedAlbums(meId);
+        return ResponseEntity.ok(list);
     }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/UpdateSharePermissionRequest.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/UpdateSharePermissionRequest.java
@@ -1,0 +1,13 @@
+package com.nemo.backend.domain.album.dto;
+
+import com.nemo.backend.domain.album.entity.AlbumShare;
+
+/**
+ * 공유 멤버 권한 변경 API 요청 DTO
+ * - PUT /api/albums/{albumId}/share/permission
+ */
+public record UpdateSharePermissionRequest(
+        Long targetUserId,          // 권한을 변경할 사용자 ID
+        AlbumShare.Role role        // 새 권한 (VIEWER / EDITOR / CO_OWNER)
+) {
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 public interface AlbumShareRepository extends JpaRepository<AlbumShare, Long> {
 
-    List<AlbumShare> findByAlbumIdAndStatusAndActiveTrue(Long albumId, Status status);
-
     List<AlbumShare> findByAlbumIdAndActiveTrue(Long albumId);
 
     Optional<AlbumShare> findByAlbumIdAndUserIdAndStatusAndActiveTrue(
@@ -19,10 +17,9 @@ public interface AlbumShareRepository extends JpaRepository<AlbumShare, Long> {
 
     List<AlbumShare> findByUserIdAndStatusAndActiveTrue(Long userId, Status status);
 
-    List<AlbumShare> findByUserIdAndActiveTrue(Long userId);
-
     boolean existsByAlbumIdAndUserIdAndActiveTrue(Long albumId, Long userId);
 
     // ⭐ 추가해야 하는 부분
     Optional<AlbumShare> findByAlbumIdAndUserIdAndActiveTrue(Long albumId, Long userId);
+
 }

--- a/backend/src/main/java/com/nemo/backend/domain/auth/controller/AuthController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/auth/controller/AuthController.java
@@ -9,7 +9,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/auth")
+@RequestMapping(value ="/api/auth",
+        produces = "application/json; charset=UTF-8")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/backend/src/main/java/com/nemo/backend/domain/auth/controller/EmailVerificationController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/auth/controller/EmailVerificationController.java
@@ -9,7 +9,10 @@ import org.springframework.web.bind.annotation.*;
 import com.nemo.backend.domain.auth.service.EmailVerificationService;
 
 @RestController
-@RequestMapping("/api/auth/email/verification")
+@RequestMapping(
+        value = "/api/auth/email/verification",
+        produces = "application/json; charset=UTF-8"
+)
 @RequiredArgsConstructor
 public class EmailVerificationController {
 

--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
@@ -1,10 +1,14 @@
 package com.nemo.backend.domain.photo.controller;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nemo.backend.domain.auth.util.AuthExtractor;          // 🔐 공통 인증 유틸
 import com.nemo.backend.domain.photo.dto.PhotoListItemDto;
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
 import com.nemo.backend.domain.photo.dto.PhotoUploadRequest;
 import com.nemo.backend.domain.photo.service.PhotoService;
+import com.nemo.backend.global.exception.ApiException;
+import com.nemo.backend.global.exception.ErrorCode;
 import com.nemo.backend.web.PageMetaDto;
 import com.nemo.backend.web.PagedResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -25,62 +29,56 @@ import java.util.*;
 @SecurityRequirement(name = "BearerAuth")
 @RestController
 @RequestMapping("/api/photos")
-@RequiredArgsConstructor // ⭐ final 필드들 자동 생성자 주입
+@RequiredArgsConstructor
 public class PhotoController {
 
-    // --------------------------------------------------------
-    // ⭐ 의존성 주입
-    // --------------------------------------------------------
     private final PhotoService photoService;
-
-    /**
-     * 🔐 AuthExtractor
-     * - Authorization 헤더에서 userId를 꺼내는 공통 로직
-     *   (JWT 검증 + RefreshToken 존재 여부까지 포함)
-     * - UserAuthController, AlbumController 등과 동일하게 사용
-     */
     private final AuthExtractor authExtractor;
 
+    private static final ObjectMapper JSON = new ObjectMapper();
+
     // ========================================================
-    // 1) 사진 업로드 (QR / 파일 둘 다 지원)
+    // 1) QR 기반 사진 업로드  (POST /api/photos)
+    //    - 명세 기준: qrCode + image + 메타데이터
+    //    - 구현: qrCode / image 둘 중 최소 하나는 필수
     // ========================================================
-    @Operation(summary = "QR/파일 업로드(둘 중 하나)", requestBody = @RequestBody(
-            content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)))
+    @Operation(
+            summary = "QR 사진 업로드",
+            description = "포토부스 QR 기반으로 사진을 업로드합니다.",
+            requestBody = @RequestBody(
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            )
+    )
     @PostMapping(
-            consumes = {
-                    MediaType.MULTIPART_FORM_DATA_VALUE,
-                    MediaType.APPLICATION_FORM_URLENCODED_VALUE,
-                    MediaType.APPLICATION_JSON_VALUE
-            },
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<PhotoUploadResponse> upload(
+    public ResponseEntity<PhotoUploadResponse> uploadByQr(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
 
-            // A) 순수 파일 업로드 경로
+            // 명세서 기준 필드명
+            @RequestPart(value = "qrCode", required = false) String qrCode,
             @RequestPart(value = "image", required = false) MultipartFile image,
-
-            // B) URL 업로드 경로 (qrCode/qrUrl 둘 다 받되, qrUrl 우선)
-            @RequestParam(value = "qrUrl",  required = false) String qrUrl,
-            @RequestParam(value = "qrCode", required = false) String qrCode,
-
-            // 보조 필드들
-            @RequestParam(value = "brand",    required = false) String brand,
-            @RequestParam(value = "location", required = false) String location,
-            @RequestParam(value = "takenAt",  required = false)
+            @RequestPart(value = "takenAt", required = false)
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime takenAt,
-
-            @RequestParam(value = "tagList",       required = false) String tagListJson,
-            @RequestParam(value = "friendIdList",  required = false) String friendIdListJson,
-            @RequestParam(value = "memo",          required = false) String memo
+            @RequestPart(value = "location", required = false) String location,
+            @RequestPart(value = "brand", required = false) String brand,
+            @RequestPart(value = "tagList", required = false) String tagListJson,
+            @RequestPart(value = "friendIdList", required = false) String friendIdListJson,
+            @RequestPart(value = "memo", required = false) String memo
     ) {
-        // 🔐 공통 유틸을 통해 JWT + RefreshToken 검증 후 userId 추출
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
-        // 하나의 DTO로 합성해 서비스로 전달
+        // ✅ 최소 조건 체크: qrCode 또는 image 둘 중 하나는 있어야 함
+        if ((qrCode == null || qrCode.isBlank())
+                && (image == null || image.isEmpty())) {
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "image 또는 qrCode 중 하나는 필수입니다. (IMAGE_REQUIRED)");
+        }
+
+        // 하나의 DTO로 합성(필요하면 서비스에서 더 세부 분기)
         PhotoUploadRequest req = new PhotoUploadRequest(
                 image,
-                (qrUrl != null && !qrUrl.isBlank()) ? qrUrl : qrCode, // qrUrl 우선, 없으면 qrCode 사용
+                qrCode,    // qrUrlOrPayload 용도로 사용
                 qrCode,
                 (takenAt != null) ? takenAt.toString() : null,
                 location,
@@ -88,10 +86,88 @@ public class PhotoController {
                 memo
         );
 
-        // 실제 업로드 처리 (서비스 내부에서 QR / 파일 분기)
         PhotoResponseDto dto = photoService.uploadHybrid(
                 userId,
-                req.qrUrl(),
+                req.qrUrl(),      // qrUrlOrPayload
+                req.image(),
+                brand,
+                location,
+                takenAt,
+                tagListJson,
+                friendIdListJson,
+                memo
+        );
+
+        // 응답 DTO 구성 (명세서 기준)
+        String isoTakenAt = (dto.getTakenAt() != null)
+                ? dto.getTakenAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                : (takenAt != null ? takenAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) : null);
+
+        List<String> tagList = parseStringArray(tagListJson);
+        List<FriendDto> friendList = parseFriendList(friendIdListJson);
+
+        PhotoUploadResponse resp = new PhotoUploadResponse(
+                dto.getId(),
+                dto.getImageUrl(),
+                isoTakenAt,
+                (location != null ? location : null),
+                (dto.getBrand() != null ? dto.getBrand() : brand),
+                tagList,
+                friendList,
+                (memo != null ? memo : "")
+        );
+
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(resp);
+    }
+
+    // ========================================================
+    // 2) 갤러리 사진 업로드  (POST /api/photos/gallery)
+    // ========================================================
+    @Operation(
+            summary = "갤러리 사진 업로드",
+            description = "휴대폰 갤러리에서 선택한 사진을 업로드합니다.",
+            requestBody = @RequestBody(
+                    content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE)
+            )
+    )
+    @PostMapping(
+            value = "/gallery",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE
+    )
+    public ResponseEntity<PhotoUploadResponse> uploadFromGallery(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @RequestPart(value = "image", required = true) MultipartFile image,
+            @RequestPart(value = "takenAt", required = false)
+            @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime takenAt,
+            @RequestPart(value = "location", required = false) String location,
+            @RequestPart(value = "brand", required = false) String brand,
+            @RequestPart(value = "tagList", required = false) String tagListJson,
+            @RequestPart(value = "friendIdList", required = false) String friendIdListJson,
+            @RequestPart(value = "memo", required = false) String memo
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+
+        if (image == null || image.isEmpty()) {
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "사진 파일은 필수입니다. (IMAGE_REQUIRED)");
+        }
+
+        PhotoUploadRequest req = new PhotoUploadRequest(
+                image,
+                null,           // qrUrl 없음 (갤러리 업로드)
+                null,
+                (takenAt != null) ? takenAt.toString() : null,
+                location,
+                brand,
+                memo
+        );
+
+        PhotoResponseDto dto = photoService.uploadHybrid(
+                userId,
+                null,           // qrUrlOrPayload 없음
                 req.image(),
                 brand,
                 location,
@@ -103,16 +179,19 @@ public class PhotoController {
 
         String isoTakenAt = (dto.getTakenAt() != null)
                 ? dto.getTakenAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
-                : LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+                : (takenAt != null ? takenAt.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) : null);
+
+        List<String> tagList = parseStringArray(tagListJson);
+        List<FriendDto> friendList = parseFriendList(friendIdListJson);
 
         PhotoUploadResponse resp = new PhotoUploadResponse(
                 dto.getId(),
                 dto.getImageUrl(),
                 isoTakenAt,
-                (location != null ? location : ""),
-                (dto.getBrand() != null ? dto.getBrand() : ""),
-                Collections.emptyList(),   // TODO: 태그/친구 리스트 연동 시 교체
-                Collections.emptyList(),
+                (location != null ? location : null),
+                (dto.getBrand() != null ? dto.getBrand() : brand),
+                tagList,
+                friendList,
                 (memo != null ? memo : "")
         );
 
@@ -123,7 +202,7 @@ public class PhotoController {
     }
 
     // ========================================================
-    // 2) 사진 목록 조회
+    // 3) 사진 목록 조회  (GET /api/photos)
     // ========================================================
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<PagedResponse<PhotoListItemDto>> list(
@@ -136,7 +215,7 @@ public class PhotoController {
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
-        // 정렬 파라미터 처리
+        // 정렬 처리 (takenAt / createdAt / id)
         Sort sort = Sort.by(Sort.Direction.DESC, "takenAt");
         if (sortBy != null && !sortBy.isBlank()) {
             String[] parts = sortBy.split(",");
@@ -160,9 +239,11 @@ public class PhotoController {
                 .photoId(p.getId())
                 .imageUrl(p.getImageUrl())
                 .takenAt(p.getTakenAt() != null ? p.getTakenAt().format(ISO) : null)
-                .location(null)        // TODO: 위치 데이터 연동 시 교체
+                // TODO: locationId → 실제 장소명 매핑 필요 시 Location 엔티티와 연동
+                .location(null)
                 .brand(p.getBrand())
-                .isFavorite(false)     // TODO: 즐겨찾기 연결 시 교체
+                // TODO: 즐겨찾기 테이블 연결 시 실제 값으로 교체
+                .isFavorite(false)
                 .build()
         ).getContent();
 
@@ -177,20 +258,24 @@ public class PhotoController {
     }
 
     // ========================================================
-    // 3) 사진 삭제
+    // 4) 사진 삭제  (DELETE /api/photos/{id})
     // ========================================================
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(
+    public ResponseEntity<Map<String, Object>> delete(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable("id") Long photoId) {
 
         Long userId = authExtractor.extractUserId(authorizationHeader);
         photoService.delete(userId, photoId);
-        return ResponseEntity.noContent().build();
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("photoId", photoId);
+        body.put("message", "사진이 성공적으로 삭제되었습니다.");
+        return ResponseEntity.ok(body);
     }
 
     // ========================================================
-    // 명세용 응답 DTO (Swagger 문서용)
+    // 내부용 DTO & 유틸
     // ========================================================
     public static record PhotoUploadResponse(
             long photoId,
@@ -207,4 +292,29 @@ public class PhotoController {
             long userId,
             String nickname
     ) {}
+
+    private List<String> parseStringArray(String jsonArray) {
+        if (jsonArray == null || jsonArray.isBlank()) return Collections.emptyList();
+        try {
+            return JSON.readValue(jsonArray, new TypeReference<List<String>>() {});
+        } catch (Exception e) {
+            // 형식 이상이면 무시하고 빈 리스트로
+            return Collections.emptyList();
+        }
+    }
+
+    private List<FriendDto> parseFriendList(String friendIdListJson) {
+        if (friendIdListJson == null || friendIdListJson.isBlank()) return Collections.emptyList();
+        try {
+            List<Long> ids = JSON.readValue(friendIdListJson, new TypeReference<List<Long>>() {});
+            List<FriendDto> result = new ArrayList<>();
+            for (Long id : ids) {
+                // TODO: UserRepository 통해 닉네임 조회 후 세팅
+                result.add(new FriendDto(id, ""));
+            }
+            return result;
+        } catch (Exception e) {
+            return Collections.emptyList();
+        }
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoResponseDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoResponseDto.java
@@ -5,7 +5,7 @@ import com.nemo.backend.domain.photo.entity.Photo;
 import java.time.LocalDateTime;
 
 /**
- * 사진 상세/목록 조회용 DTO. 기존 스키마를 유지한다.
+ * 사진 상세/목록 조회용 DTO.
  */
 public class PhotoResponseDto {
     private Long id;
@@ -17,8 +17,11 @@ public class PhotoResponseDto {
     private String brand;
     private LocalDateTime takenAt;
     private Long locationId;
+    private String locationName;
     private String qrHash;
     private LocalDateTime createdAt;
+    private boolean favorite;
+    private String memo;
 
     public PhotoResponseDto(Photo photo) {
         this.id = photo.getId();
@@ -30,52 +33,25 @@ public class PhotoResponseDto {
         this.brand = photo.getBrand();
         this.takenAt = photo.getTakenAt();
         this.locationId = photo.getLocationId();
+        this.locationName = photo.getLocationName();
         this.qrHash = photo.getQrHash();
         this.createdAt = photo.getCreatedAt();
+        this.favorite = Boolean.TRUE.equals(photo.getFavorite());
+        this.memo = photo.getMemo();
     }
 
-    // getters
-    public Long getId() {
-        return id;
-    }
-
-    public Long getUserId() {
-        return userId;
-    }
-
-    public Long getAlbumId() {
-        return albumId;
-    }
-
-    public String getImageUrl() {
-        return imageUrl;
-    }
-
-    public String getThumbnailUrl() {
-        return thumbnailUrl;
-    }
-
-    public String getVideoUrl() {
-        return videoUrl;
-    }
-
-    public String getBrand() {
-        return brand;
-    }
-
-    public LocalDateTime getTakenAt() {
-        return takenAt;
-    }
-
-    public Long getLocationId() {
-        return locationId;
-    }
-
-    public String getQrHash() {
-        return qrHash;
-    }
-
-    public LocalDateTime getCreatedAt() {
-        return createdAt;
-    }
+    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
+    public Long getAlbumId() { return albumId; }
+    public String getImageUrl() { return imageUrl; }
+    public String getThumbnailUrl() { return thumbnailUrl; }
+    public String getVideoUrl() { return videoUrl; }
+    public String getBrand() { return brand; }
+    public LocalDateTime getTakenAt() { return takenAt; }
+    public Long getLocationId() { return locationId; }
+    public String getLocationName() { return locationName; }
+    public String getQrHash() { return qrHash; }
+    public LocalDateTime getCreatedAt() { return createdAt; }
+    public boolean isFavorite() { return favorite; }
+    public String getMemo() { return memo; }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
@@ -1,3 +1,4 @@
+// com.nemo.backend.domain.photo.entity.Photo
 package com.nemo.backend.domain.photo.entity;
 
 import com.nemo.backend.domain.album.entity.Album;
@@ -27,12 +28,28 @@ public class Photo {
     private String imageUrl;
     private String thumbnailUrl;
     private String videoUrl;
+
     private LocalDateTime takenAt;
+
+    /** 장소 ID (추후 Location 엔티티용) */
     private Long locationId;
+
+    /** 장소명(문자열) – 명세서의 location 필드용 */
+    @Column(name = "location_name")
+    private String locationName;
+
     private String brand;
 
     @Column(unique = true)
     private String qrHash;
+
+    /** 즐겨찾기 여부 (기본 false) */
+    @Column(name = "favorite")
+    private Boolean favorite = false;
+
+    /** 메모(상세 편집에서 사용하는 필드) */
+    @Column(name = "memo", length = 300)
+    private String memo;
 
     private LocalDateTime createdAt = LocalDateTime.now();
     private Boolean deleted = false;
@@ -67,20 +84,37 @@ public class Photo {
 
     public String getImageUrl() { return imageUrl; }
     public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
+
     public String getThumbnailUrl() { return thumbnailUrl; }
     public void setThumbnailUrl(String thumbnailUrl) { this.thumbnailUrl = thumbnailUrl; }
+
     public String getVideoUrl() { return videoUrl; }
     public void setVideoUrl(String videoUrl) { this.videoUrl = videoUrl; }
+
     public LocalDateTime getTakenAt() { return takenAt; }
     public void setTakenAt(LocalDateTime takenAt) { this.takenAt = takenAt; }
+
     public Long getLocationId() { return locationId; }
     public void setLocationId(Long locationId) { this.locationId = locationId; }
+
+    public String getLocationName() { return locationName; }
+    public void setLocationName(String locationName) { this.locationName = locationName; }
+
     public String getBrand() { return brand; }
     public void setBrand(String brand) { this.brand = brand; }
+
     public String getQrHash() { return qrHash; }
     public void setQrHash(String qrHash) { this.qrHash = qrHash; }
+
+    public Boolean getFavorite() { return favorite; }
+    public void setFavorite(Boolean favorite) { this.favorite = favorite; }
+
+    public String getMemo() { return memo; }
+    public void setMemo(String memo) { this.memo = memo; }
+
     public LocalDateTime getCreatedAt() { return createdAt; }
     public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
+
     public Boolean getDeleted() { return deleted; }
     public void setDeleted(Boolean deleted) { this.deleted = deleted; }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -15,6 +15,9 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
     Page<Photo> findByUserIdAndDeletedIsFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
+    // ✅ 즐겨찾기만 필터
+    Page<Photo> findByUserIdAndDeletedIsFalseAndFavoriteTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
+
     // ✅ 앨범 내 사진들 (삭제 안 된 것만) 최신순
     List<Photo> findByAlbum_IdAndDeletedIsFalseOrderByCreatedAtDesc(Long albumId);
 

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -1,3 +1,5 @@
+// backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+
 package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
@@ -11,7 +13,7 @@ public interface PhotoService {
 
     PhotoResponseDto uploadHybrid(
             Long userId,
-            String qrCode,
+            String qrCodeOrUrl,
             MultipartFile image,
             String brand,
             String location,
@@ -21,7 +23,26 @@ public interface PhotoService {
             String memo
     );
 
-    Page<PhotoResponseDto> list(Long userId, Pageable pageable);
+    // ✅ favorite 필터 적용 가능하도록 확장
+    Page<PhotoResponseDto> list(Long userId, Pageable pageable, Boolean favorite);
+
+    // ✅ 기존 컨트롤러 호환용 오버로드
+    default Page<PhotoResponseDto> list(Long userId, Pageable pageable) {
+        return list(userId, pageable, null);
+    }
 
     void delete(Long userId, Long photoId);
+
+    PhotoResponseDto getDetail(Long userId, Long photoId);
+
+    PhotoResponseDto updateDetails(
+            Long userId,
+            Long photoId,
+            LocalDateTime takenAt,
+            String location,
+            String brand,
+            String memo
+    );
+
+    boolean toggleFavorite(Long userId, Long photoId);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/user/controller/UserAuthController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/controller/UserAuthController.java
@@ -17,7 +17,9 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Map;
 
 @RestController
-@RequestMapping(value = "/api/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(
+        value = "/api/users",
+        produces = "application/json; charset=UTF-8")
 @RequiredArgsConstructor // 🔥 final 필드 자동 생성자
 public class UserAuthController {
 

--- a/backend/src/main/java/com/nemo/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/controller/UserController.java
@@ -1,83 +1,124 @@
-// backend/src/main/java/com/nemo/backend/domain/user/controller/UserController.java
 package com.nemo.backend.domain.user.controller;
 
 import com.nemo.backend.domain.auth.dto.DeleteAccountRequest;
 import com.nemo.backend.domain.auth.service.AuthService;
-import com.nemo.backend.domain.auth.util.AuthExtractor;      // 🔐 공통 인증 유틸
+import com.nemo.backend.domain.auth.util.AuthExtractor;
+import com.nemo.backend.domain.user.dto.UpdateUserRequest;
 import com.nemo.backend.domain.user.dto.UserProfileResponse;
 import com.nemo.backend.domain.user.entity.User;
 import com.nemo.backend.domain.user.repository.UserRepository;
+import com.nemo.backend.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.Map;
 
 @RestController
 @RequestMapping(value = "/api/users", produces = MediaType.APPLICATION_JSON_VALUE)
-@RequiredArgsConstructor // ⭐ final 필드 자동 생성자 주입
+@RequiredArgsConstructor
 public class UserController {
 
-    // --------------------------------------------------------
-    // ⭐ 의존성 주입
-    // --------------------------------------------------------
     private final UserRepository userRepository;
     private final AuthService authService;
-
-    /**
-     * 🔐 AuthExtractor
-     * - Authorization 헤더에서 userId를 꺼내는 공통 로직
-     *   (JWT 검증 + RefreshToken 존재 여부까지 포함)
-     * - UserAuthController, AlbumController, PhotoController와 동일하게 사용
-     */
     private final AuthExtractor authExtractor;
+    private final UserService userService;
 
     // ========================================================
     // 1) 내 정보 조회 (GET /api/users/me)
     // ========================================================
-    @GetMapping(value = "/me", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping("/me")
     public ResponseEntity<UserProfileResponse> getMe(HttpServletRequest request) {
 
-        // 1) Authorization 헤더에서 userId 추출
         String authorization = request.getHeader("Authorization");
         Long userId = authExtractor.extractUserId(authorization);
 
-        // 2) DB에서 사용자 정보 조회
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
 
-        // 3) 프로필 응답 DTO로 변환
         UserProfileResponse body = new UserProfileResponse(
                 user.getId(),
                 user.getEmail(),
                 user.getNickname(),
                 user.getProfileImageUrl(),
-                user.getCreatedAt()   // BaseEntity에서 상속받음
+                user.getCreatedAt()
         );
 
         return ResponseEntity.ok(body);
     }
 
     // ========================================================
-    // 2) 회원탈퇴 (DELETE /api/users/me)
-    //    - 비밀번호 검증 + 계정/리프레시 토큰 삭제
+    // 2) 내 정보 수정 (PUT /api/users/me)
+    //    - JSON Body: { nickname, profileImageUrl }
+    // ========================================================
+    @PutMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<Map<String, Object>> updateMe(
+            HttpServletRequest request,
+            @RequestBody UpdateUserRequest updateRequest
+    ) {
+        String authorization = request.getHeader("Authorization");
+        Long userId = authExtractor.extractUserId(authorization);
+
+        User updated = userService.updateProfile(userId, updateRequest);
+
+        UserProfileResponse profile = new UserProfileResponse(
+                updated.getId(),
+                updated.getEmail(),
+                updated.getNickname(),
+                updated.getProfileImageUrl(),
+                updated.getCreatedAt()
+        );
+
+        return ResponseEntity.ok(Map.of(
+                "userId", profile.getUserId(),
+                "email", profile.getEmail(),
+                "nickname", profile.getNickname(),
+                "profileImageUrl", profile.getProfileImageUrl(),
+                "updatedAt", profile.getCreatedAt()
+        ));
+    }
+
+    // ========================================================
+    // 3) 프로필 이미지 업로드 (POST /api/users/me/profile-image)
+    //    - multipart/form-data
+    //    - field name: image
+    // ========================================================
+    @PostMapping(
+            value = "/me/profile-image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<Map<String, String>> uploadProfileImage(
+            HttpServletRequest request,
+            @RequestPart("image") MultipartFile image
+    ) {
+        String authorization = request.getHeader("Authorization");
+        Long userId = authExtractor.extractUserId(authorization);
+
+        String profileUrl = userService.uploadProfileImage(userId, image);
+
+        return ResponseEntity.ok(Map.of(
+                "profileImageUrl", profileUrl,
+                "message", "프로필 이미지가 성공적으로 업로드되었습니다."
+        ));
+    }
+
+    // ========================================================
+    // 4) 회원탈퇴 (DELETE /api/users/me)
     // ========================================================
     @DeleteMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, String>> deleteMe(
             @Valid @RequestBody DeleteAccountRequest body,
             HttpServletRequest httpRequest
     ) {
-        // 1) Authorization 헤더에서 userId 추출 (JWT + RefreshToken 검증 포함)
         String authorization = httpRequest.getHeader("Authorization");
         Long userId = authExtractor.extractUserId(authorization);
 
-        // 2) 비밀번호 검증 + 실제 탈퇴 처리 (AuthService에 위임)
         authService.deleteAccount(userId, body.getPassword());
 
-        // 3) 결과 메시지 반환
         return ResponseEntity.ok(Map.of("message", "회원탈퇴 완료"));
     }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/user/controller/UserController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/controller/UserController.java
@@ -1,3 +1,5 @@
+// com.nemo.backend.domain.user.controller.UserController
+
 package com.nemo.backend.domain.user.controller;
 
 import com.nemo.backend.domain.auth.dto.DeleteAccountRequest;
@@ -16,10 +18,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 @RestController
-@RequestMapping(value = "/api/users", produces = MediaType.APPLICATION_JSON_VALUE)
+@RequestMapping(
+        value = "/api/users",
+        produces = "application/json; charset=UTF-8")
 @RequiredArgsConstructor
 public class UserController {
 
@@ -52,11 +57,11 @@ public class UserController {
     }
 
     // ========================================================
-    // 2) 내 정보 수정 (PUT /api/users/me)
-    //    - JSON Body: { nickname, profileImageUrl }
+    // 2-1) 내 정보 수정 (JSON, PUT /api/users/me)
+    //    - Body: { nickname, profileImageUrl }
     // ========================================================
     @PutMapping(value = "/me", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public ResponseEntity<Map<String, Object>> updateMe(
+    public ResponseEntity<Map<String, Object>> updateMeJson(
             HttpServletRequest request,
             @RequestBody UpdateUserRequest updateRequest
     ) {
@@ -83,9 +88,48 @@ public class UserController {
     }
 
     // ========================================================
-    // 3) 프로필 이미지 업로드 (POST /api/users/me/profile-image)
-    //    - multipart/form-data
-    //    - field name: image
+    // 2-2) 내 정보 수정 (multipart/form-data, PUT /api/users/me)
+    //    - field:
+    //        nickname: 텍스트 (옵션)
+    //        image:    파일   (옵션)
+    // ========================================================
+    @PutMapping(
+            value = "/me",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    public ResponseEntity<Map<String, Object>> updateMeMultipart(
+            HttpServletRequest request,
+            @RequestPart(value = "nickname", required = false) String rawNickname,
+            @RequestPart(value = "image", required = false) MultipartFile image
+    ) {
+        String authorization = request.getHeader("Authorization");
+        Long userId = authExtractor.extractUserId(authorization);
+
+        // 🔤 multipart 한글 깨짐 방지: ISO-8859-1 → UTF-8 재변환
+        String nickname = decodeIfIso8859(rawNickname);
+
+        User updated = userService.updateProfileMultipart(userId, nickname, image);
+
+        UserProfileResponse profile = new UserProfileResponse(
+                updated.getId(),
+                updated.getEmail(),
+                updated.getNickname(),
+                updated.getProfileImageUrl(),
+                updated.getCreatedAt()
+        );
+
+        return ResponseEntity.ok(Map.of(
+                "userId", profile.getUserId(),
+                "email", profile.getEmail(),
+                "nickname", profile.getNickname(),
+                "profileImageUrl", profile.getProfileImageUrl(),
+                "updatedAt", profile.getCreatedAt()
+        ));
+    }
+
+    // ========================================================
+    // 3) (선택) 프로필 이미지 전용 업로드
+    //    - 프론트가 쓰기 싫으면 안 써도 됨
     // ========================================================
     @PostMapping(
             value = "/me/profile-image",
@@ -120,5 +164,34 @@ public class UserController {
         authService.deleteAccount(userId, body.getPassword());
 
         return ResponseEntity.ok(Map.of("message", "회원탈퇴 완료"));
+    }
+
+    // ========================================================
+    // 내부 유틸: ISO-8859-1 로 잘못 디코딩된 문자열을 UTF-8 로 복원
+    // ========================================================
+    private String decodeIfIso8859(String value) {
+        if (value == null || value.isBlank()) return value;
+
+        // 이미 한글이 제대로 들어온 경우(Hangul 영역) 그냥 리턴
+        boolean hasHangul = value.codePoints()
+                .anyMatch(cp ->
+                        (cp >= 0xAC00 && cp <= 0xD7AF) || // Hangul Syllables
+                                (cp >= 0x1100 && cp <= 0x11FF));  // Hangul Jamo
+
+        if (hasHangul) {
+            return value;
+        }
+
+        // C1 영역(0xC0~0xFF) 글자가 많이 포함돼 있으면 모지바케로 간주하고 재디코딩
+        long suspicious = value.chars()
+                .filter(ch -> ch >= 0xC0 && ch <= 0xFF)
+                .count();
+
+        if (suspicious == 0) {
+            return value;
+        }
+
+        byte[] isoBytes = value.getBytes(StandardCharsets.ISO_8859_1);
+        return new String(isoBytes, StandardCharsets.UTF_8);
     }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/user/dto/UpdateUserRequest.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/dto/UpdateUserRequest.java
@@ -1,19 +1,17 @@
 package com.nemo.backend.domain.user.dto;
 
 /**
- * Payload for updating user profile information.  All fields are optional; any
- * provided fields will overwrite the corresponding values on the user
- * entity.
+ * Payload for updating user profile information.
+ * 모든 필드는 optional 이고,
+ * 넘겨진 값만 업데이트한다.
  */
 public class UpdateUserRequest {
     private String nickname;
     private String profileImageUrl;
-    private String password;
 
     public String getNickname() {
         return nickname;
     }
-
     public void setNickname(String nickname) {
         this.nickname = nickname;
     }
@@ -21,16 +19,12 @@ public class UpdateUserRequest {
     public String getProfileImageUrl() {
         return profileImageUrl;
     }
-
     public void setProfileImageUrl(String profileImageUrl) {
         this.profileImageUrl = profileImageUrl;
     }
 
-    public String getPassword() {
-        return password;
-    }
-
-    public void setPassword(String password) {
-        this.password = password;
+    public boolean hasAnyField() {
+        return (nickname != null && !nickname.isEmpty())
+                || (profileImageUrl != null && !profileImageUrl.isEmpty());
     }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/user/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/dto/UserProfileResponse.java
@@ -6,33 +6,38 @@ import java.time.LocalDateTime;
  * 현재 로그인한 사용자의 프로필 정보를 나타내는 DTO.
  * null 값이 전달될 경우 빈 문자열로 대체하여 Flutter에서
  *  `Null is not a subtype of String` 오류를 방지합니다.
+ *
+ * 응답 JSON 필드:
+ *  - userId
+ *  - email
+ *  - nickname
+ *  - profileImageUrl
+ *  - createdAt
  */
 public class UserProfileResponse {
-    private Long id;             // 사용자 ID
-    private String email;        // 이메일
-    private String nickname;     // 닉네임 (null → "")
-    private String profileImage; // 프로필 이미지 URL (null → "")
-    private String createdAt;    // 가입일 (ISO‑8601 문자열)
+    private Long userId;             // ✅ 명세: userId
+    private String email;
+    private String nickname;
+    private String profileImageUrl;  // ✅ 명세: profileImageUrl
+    private String createdAt;        // ISO-8601 문자열
 
-    // 기본 생성자
     public UserProfileResponse() {}
 
-    public UserProfileResponse(Long id,
+    public UserProfileResponse(Long userId,
                                String email,
                                String nickname,
-                               String profileImage,
+                               String profileImageUrl,
                                LocalDateTime createdAt) {
-        this.id = (id == null ? 0L : id);
+        this.userId = (userId == null ? 0L : userId);
         this.email = (email == null ? "" : email);
         this.nickname = (nickname == null ? "" : nickname);
-        this.profileImage = (profileImage == null ? "" : profileImage);
+        this.profileImageUrl = (profileImageUrl == null ? "" : profileImageUrl);
         this.createdAt = (createdAt == null ? "" : createdAt.toString());
     }
 
-    // 게터들
-    public Long getId() { return id; }
+    public Long getUserId() { return userId; }
     public String getEmail() { return email; }
     public String getNickname() { return nickname; }
-    public String getProfileImage() { return profileImage; }
+    public String getProfileImageUrl() { return profileImageUrl; }
     public String getCreatedAt() { return createdAt; }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/service/UserService.java
@@ -1,3 +1,5 @@
+// com.nemo.backend.domain.user.service.UserService
+
 package com.nemo.backend.domain.user.service;
 
 import com.nemo.backend.domain.photo.service.PhotoStorage;
@@ -7,22 +9,17 @@ import com.nemo.backend.domain.user.repository.UserRepository;
 import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-/**
- * Service layer for reading and updating user profile information.
- */
 @Service
 public class UserService {
 
     private final UserRepository userRepository;
     private final PhotoStorage photoStorage;
-    private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-    private final String publicBaseUrl;  // ex) http://localhost:8080 or https://api.nemo.app
+    private final String publicBaseUrl;  // ex) http://localhost:8080
 
     public UserService(UserRepository userRepository,
                        PhotoStorage photoStorage,
@@ -38,6 +35,9 @@ public class UserService {
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_ALREADY_DELETED));
     }
 
+    // =========================
+    // JSON 기반 프로필 수정 (닉네임, URL 직접 설정)
+    // =========================
     @Transactional
     public User updateProfile(Long userId, UpdateUserRequest request) {
         if (request == null || !request.hasAnyField()) {
@@ -52,16 +52,51 @@ public class UserService {
         }
 
         if (request.getProfileImageUrl() != null && !request.getProfileImageUrl().isEmpty()) {
-            // 프론트에서 S3 URL을 직접 줄 수도 있으니 허용
+            // 프론트가 이미 S3 URL을 알고 있는 경우 그대로 반영
             user.setProfileImageUrl(request.getProfileImageUrl());
         }
 
         return user;
     }
 
+    // =========================
+    // multipart/form-data 기반 프로필 수정
+    //  - 닉네임(옵션)
+    //  - 이미지 파일(옵션, 있으면 S3 업로드)
+    // =========================
+    @Transactional
+    public User updateProfileMultipart(Long userId, String nickname, MultipartFile image) {
+
+        if ((nickname == null || nickname.isBlank())
+                && (image == null || image.isEmpty())) {
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "수정할 항목이 없습니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_ALREADY_DELETED));
+
+        if (nickname != null && !nickname.isBlank()) {
+            user.setNickname(nickname);
+        }
+
+        if (image != null && !image.isEmpty()) {
+            try {
+                // S3 업로드 후 URL 저장
+                String key = photoStorage.store(image);           // albums/..., profiles/... 등
+                String profileUrl = publicBaseUrl + "/files/" + key;
+                user.setProfileImageUrl(profileUrl);
+            } catch (Exception e) {
+                // S3PhotoStorage 가 던지는 예외를 공통 에러 코드로 래핑
+                throw new ApiException(ErrorCode.STORAGE_FAILED,
+                        "프로필 이미지 업로드 실패: " + e.getMessage(), e);
+            }
+        }
+
+        return user;
+    }
+
     /**
-     * 프로필 이미지 파일을 S3에 업로드하고,
-     * 업로드된 파일의 public URL을 User.profileImageUrl 에 저장한 뒤 반환.
+     * (필요하면 그대로 사용 가능한 단독 프로필 이미지 업로드)
      */
     @Transactional
     public String uploadProfileImage(Long userId, MultipartFile image) {
@@ -73,18 +108,11 @@ public class UserService {
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_ALREADY_DELETED));
 
         try {
-            // ✅ S3 업로드 (PhotoServiceImpl 이 쓰는 것과 같은 스토리지 사용)
-            String key = photoStorage.store(image);  // ex) albums/2025-11-18/...jpg
-
-            // ✅ 실제 접근 가능한 URL로 변환 (PhotoServiceImpl.toPublicUrl 과 동일 패턴)
+            String key = photoStorage.store(image);
             String profileUrl = publicBaseUrl + "/files/" + key;
-
             user.setProfileImageUrl(profileUrl);
-
             return profileUrl;
         } catch (Exception e) {
-            // S3PhotoStorage 가 이미 ApiException(STORAGE_FAILED) 를 던지고 있으니
-            // 여기선 그냥 래핑만
             throw new ApiException(ErrorCode.STORAGE_FAILED, "프로필 이미지 업로드 실패: " + e.getMessage(), e);
         }
     }

--- a/backend/src/main/java/com/nemo/backend/domain/user/service/UserService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/service/UserService.java
@@ -1,46 +1,91 @@
 package com.nemo.backend.domain.user.service;
 
+import com.nemo.backend.domain.photo.service.PhotoStorage;
 import com.nemo.backend.domain.user.dto.UpdateUserRequest;
 import com.nemo.backend.domain.user.entity.User;
 import com.nemo.backend.domain.user.repository.UserRepository;
 import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 /**
  * Service layer for reading and updating user profile information.
  */
 @Service
 public class UserService {
+
     private final UserRepository userRepository;
+    private final PhotoStorage photoStorage;
     private final BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-    public UserService(UserRepository userRepository) {
+    private final String publicBaseUrl;  // ex) http://localhost:8080 or https://api.nemo.app
+
+    public UserService(UserRepository userRepository,
+                       PhotoStorage photoStorage,
+                       @Value("${app.public-base-url:http://localhost:8080}") String publicBaseUrl) {
         this.userRepository = userRepository;
+        this.photoStorage = photoStorage;
+        this.publicBaseUrl = publicBaseUrl.replaceAll("/+$", "");
     }
 
     @Transactional(readOnly = true)
     public User getProfile(Long userId) {
-        // 탈퇴된 사용자는 USER_ALREADY_DELETED 오류로 처리
         return userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_ALREADY_DELETED));
     }
 
     @Transactional
     public User updateProfile(Long userId, UpdateUserRequest request) {
+        if (request == null || !request.hasAnyField()) {
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "수정할 항목이 없습니다.");
+        }
+
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ApiException(ErrorCode.USER_ALREADY_DELETED));
+
         if (request.getNickname() != null && !request.getNickname().isEmpty()) {
             user.setNickname(request.getNickname());
         }
-        if (request.getProfileImageUrl() != null) {
+
+        if (request.getProfileImageUrl() != null && !request.getProfileImageUrl().isEmpty()) {
+            // 프론트에서 S3 URL을 직접 줄 수도 있으니 허용
             user.setProfileImageUrl(request.getProfileImageUrl());
         }
-        if (request.getPassword() != null && !request.getPassword().isEmpty()) {
-            user.setPassword(passwordEncoder.encode(request.getPassword()));
-        }
+
         return user;
+    }
+
+    /**
+     * 프로필 이미지 파일을 S3에 업로드하고,
+     * 업로드된 파일의 public URL을 User.profileImageUrl 에 저장한 뒤 반환.
+     */
+    @Transactional
+    public String uploadProfileImage(Long userId, MultipartFile image) {
+        if (image == null || image.isEmpty()) {
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "프로필 이미지 파일은 필수입니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_ALREADY_DELETED));
+
+        try {
+            // ✅ S3 업로드 (PhotoServiceImpl 이 쓰는 것과 같은 스토리지 사용)
+            String key = photoStorage.store(image);  // ex) albums/2025-11-18/...jpg
+
+            // ✅ 실제 접근 가능한 URL로 변환 (PhotoServiceImpl.toPublicUrl 과 동일 패턴)
+            String profileUrl = publicBaseUrl + "/files/" + key;
+
+            user.setProfileImageUrl(profileUrl);
+
+            return profileUrl;
+        } catch (Exception e) {
+            // S3PhotoStorage 가 이미 ApiException(STORAGE_FAILED) 를 던지고 있으니
+            // 여기선 그냥 래핑만
+            throw new ApiException(ErrorCode.STORAGE_FAILED, "프로필 이미지 업로드 실패: " + e.getMessage(), e);
+        }
     }
 }

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -25,6 +25,12 @@ spring:
     properties:
       hibernate.format_sql: true
 
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true            # 요청/응답 모두 UTF-8로 강제
+
 app:
   jwt:
     secret: "dev-very-secret-key-change-me-32bytes-min"   # ★로컬 전용 키 (운영에선 환경변수로)
@@ -48,3 +54,7 @@ naver:
       endpoint: https://openapi.naver.com/v1/search/local.json
       client-id: ${NAVER_LOCAL_CLIENT_ID:dev-dummy}
       client-secret: ${NAVER_LOCAL_CLIENT_SECRET:dev-dummy}
+
+server:
+  tomcat:
+    uri-encoding: UTF-8      # 쿼리/폼 파라미터 UTF-8 처리


### PR DESCRIPTION
개요

사용자 프로필(닉네임, 프로필 이미지) 수정 기능을 백엔드에 추가하고,

앨범 공유 도메인을 최신 API 명세에 맞게 전반적으로 리팩터링했습니다.

로그인/회원가입 응답 DTO도 프론트에서 바로 사용할 수 있도록 정리했습니다.

주요 변경 사항
1) 인증 / 사용자 도메인
1-1. AuthService 리팩터링 (com.nemo.backend.domain.auth.service.AuthService)

기존 JWT 발급 로직을 JwtUtil 기반으로 통일

createAccessToken(userId, email) 사용

로그인 로직 정리

이메일/비밀번호 검증 후 Access Token + Refresh Token 동시 발급

RefreshToken을 DB(RefreshTokenRepository)에 저장/갱신

회원가입 로직 정리

이메일 중복/필수값 검증

비밀번호 암호화 후 User 엔티티 저장

nickname 기본값 처리, profileImageUrl는 빈 문자열로 초기화

로그아웃

해당 userId의 RefreshToken 삭제

회원탈퇴

비밀번호 검증 후 RefreshToken + User 삭제

토큰 재발급

RefreshToken 유효성 검증

Access Token 재발급

만료 임박 시 Refresh Token 회전(rotate) 로직 추가

1-2. 로그인/회원가입 응답 DTO 정리

SignUpResponse

필드: id, email, nickname, profileImageUrl

회원가입 직후 프론트에서 바로 사용자 정보를 사용할 수 있도록 구성

LoginResponse

필드: id, email, nickname, profileImageUrl, accessToken, refreshToken

프론트에서 로그인 후 UserProvider에 그대로 세팅 가능하도록 구조 통일

1-3. 사용자 인증 컨트롤러 정리 (UserAuthController)

base path: /api/users

POST /api/users/signup

SignUpRequest 입력 → SignUpResponse 반환

201 Created + application/json 응답

POST /api/users/login

LoginRequest 입력 → LoginResponse 반환

로그인 성공 시 Access/Refresh Token 및 기본 사용자 정보 반환

POST /api/users/logout

Authorization 헤더에서 토큰 추출 → AuthExtractor로 userId 해석

해당 유저의 RefreshToken 삭제 후 { "message": "logged out" } 형태로 200 OK 응답

⚠️ 이 PR 범위에서는 회원가입 시 프로필 이미지 파일 업로드는 처리하지 않음
프로필 이미지는 추후 PUT /api/users/me(multipart)에서 별도로 처리하는 플로우를 전제로 함.

2) 앨범 공유 도메인 리팩터링

앨범 공유 관련 API를 최신 명세에 맞춰 전반적으로 정리했습니다.

2-1. 공유 컨트롤러 (AlbumShareController)

base-url: /api/albums

POST /{albumId}/share

앨범 공유 요청 보내기

요청: AlbumShareRequest (friendIdList, defaultRole 등)

응답: AlbumShareResponse

GET /{albumId}/share/members

해당 앨범의 공유 멤버 목록 조회

OWNER / CO_OWNER 권한 필요

응답: AlbumShareTargetsResponse (sharedTo 리스트 포함)

PUT /{albumId}/share/permission

공유 멤버 권한 변경 (명세: targetUserId 기준)

요청: UpdateSharePermissionRequest { targetUserId, role }

응답: 200 OK (body 없음)

DELETE /{albumId}/share/{targetUserId}

공유 해제

본인이 나가기, 또는 OWNER/CO_OWNER가 다른 멤버 강퇴

응답: 204 No Content

GET /share/requests

내가 받은 앨범 공유 요청 목록 (PENDING)

응답: List<PendingShareResponse>

POST /{albumId}/share/accept

해당 앨범에 대한 공유 요청 수락

응답: 200 OK

POST /{albumId}/share/reject

해당 앨범에 대한 공유 요청 거절

응답: 200 OK

POST /{albumId}/share/link

공유 링크 생성 (임시 구현)

응답: AlbumShareLinkResponse (albumId, shareUrl)

2-2. 공유 서비스 (AlbumShareService)

getAlbum(Long albumId)

앨범 단건 조회, 없으면 NOT_FOUND(ALBUM_NOT_FOUND)

getAlbumWithManagePermission(Long albumId, Long meId)

OWNER or CO_OWNER 권한 검증용 헬퍼

shareAlbum(Long albumId, Long meId, AlbumShareRequest req)

OWNER/CO_OWNER만 호출 가능

friendIdList 중복 제거 및 이미 공유된 사용자 제거

친구 관계(FriendStatus.ACCEPTED)가 아닌 대상이 있으면 에러

AlbumShare 엔티티 생성 후 저장, AlbumShareResponse로 응답

getShareTargets(Long albumId, Long meId)

앨범 공유 멤버 목록 조회

OWNER/CO_OWNER 권한 필수

updateShareRoleByUserId(Long albumId, Long targetUserId, Long meId, Role newRole)

AlbumShareRepository.findByAlbumIdAndUserIdAndActiveTrue 사용

활성 + ACCEPTED 상태인지 검증 후 role 변경

unshare(Long albumId, Long targetUserId, Long meId)

targetUserId == meId → 본인이 나가기

그 외 → OWNER 또는 CO_OWNER만 다른 멤버 강퇴 가능

이미 비활성화된 공유는 예외 처리

getPendingShares(Long meId)

내가 받은 PENDING 공유 요청 목록 반환

acceptShareByAlbum(Long albumId, Long meId) / rejectShareByAlbum(Long albumId, Long meId)

albumId + meId + Status.PENDING 기준으로 공유 요청 찾은 후 수락/거절 처리

getMySharedAlbums(Long meId)

내가 공유받은(ACCEPTED) 앨범 목록 반환

SharedAlbumSummaryResponse DTO로 매핑

createShareLink(Long albumId, Long meId)

OWNER/CO_OWNER 권한 검증 후 임시 share URL 생성 (추후 토큰 기반으로 개선 예정)

2-3. 공유 관련 Repository 변경 (AlbumShareRepository)

기존 메서드 유지 + 추가:

Optional<AlbumShare> findByAlbumIdAndUserIdAndActiveTrue(Long albumId, Long userId);

권한 변경 및 공유 해제 시 공통으로 사용

기타 사용 메서드:

findByAlbumIdAndActiveTrue

findByAlbumIdAndUserIdAndStatusAndActiveTrue

findByUserIdAndStatusAndActiveTrue

existsByAlbumIdAndUserIdAndActiveTrue

2-4. DTO 추가 (SharedAlbumSummaryResponse)

목적: GET /api/albums/shared 에서 사용할 요약용 DTO

필드:

albumId

title

description

coverPhotoUrl

ownerId

ownerNickname

myRole (AlbumShare.Role)

sharedAt

photoCount

static from(Album album, AlbumShare share, String resolvedCoverUrl, int photoCount) 팩토리 메서드 제공

API 변화 요약 (백엔드 기준)

기존 엔드포인트 정리

/api/users/signup → SignUpResponse 구조 확정

/api/users/login → LoginResponse에 id, nickname, profileImageUrl, accessToken, refreshToken 포함

/api/users/logout → AuthExtractor 기반으로 userId 추출 후 로그아웃 처리

앨범 공유 관련 엔드포인트 명세와 일치하도록 정리

POST /api/albums/{albumId}/share

GET /api/albums/{albumId}/share/members

PUT /api/albums/{albumId}/share/permission

DELETE /api/albums/{albumId}/share/{targetUserId}

GET /api/albums/share/requests

POST /api/albums/{albumId}/share/accept

POST /api/albums/{albumId}/share/reject

POST /api/albums/{albumId}/share/link

프론트엔드에서는 앨범 공유/요청/멤버 조회 API를 위 엔드포인트와 응답 DTO 구조에 맞춰 사용하면 됩니다.
(이 PR 설명에서는 프론트 변경 내용은 의도적으로 제외했습니다.)

테스트

로컬 H2 + dev 프로파일에서 수동 테스트

/api/users/signup, /api/users/login, /api/users/logout 시나리오 검증

/api/albums/{albumId}/share ~ /share/accept / /share/reject 전체 플로우 동작 확인

실제 토큰 포함 요청은 curl / Postman / Flutter 앱을 통해 확인