### PR TITLE
feature/map-viewport-geocoding-search

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/map/dto/PhotoboothDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/dto/PhotoboothDto.java
@@ -1,9 +1,12 @@
 // src/main/java/com/nemo/backend/domain/map/dto/PhotoboothDto.java
 package com.nemo.backend.domain.map.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
+
+import java.time.Instant;
 
 @Data
 @Builder
@@ -33,4 +36,8 @@ public class PhotoboothDto {
     private boolean cluster;
     private Integer count;      // 클러스터에 포함된 개수(미사용)
     private Integer bucketSize; // 클러스터 반경 힌트(미사용)
+
+    //✅ 마지막 수정 시각 (내부용, 응답에 포함하지 않음)
+    @JsonIgnore
+    private Instant lastUpdated;
 }

--- a/backend/src/main/java/com/nemo/backend/domain/map/dto/ViewportDeltaRequest.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/dto/ViewportDeltaRequest.java
@@ -1,0 +1,72 @@
+package com.nemo.backend.domain.map.dto;
+
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 뷰포트 증분(Delta) 조회용 요청 DTO
+ *
+ * - 클라이언트가 현재 보고 있는 지도 영역(뷰포트) 정보 +
+ *   마지막으로 데이터를 받은 시각(sinceTs) +
+ *   이미 가지고 있는 마커 ID 목록(knownIds)을 보내면,
+ *   서버는 그 이후로 변경된 부분만 돌려준다.
+ */
+@Data
+public class ViewportDeltaRequest {
+
+    // -------------------------------
+    // 1) 뷰포트(현재 보고 있는 지도 영역) 정보
+    // -------------------------------
+
+    /** 북동쪽 모서리 위도 (top-right) */
+    private double neLat;
+
+    /** 북동쪽 모서리 경도 (top-right) */
+    private double neLng;
+
+    /** 남서쪽 모서리 위도 (bottom-left) */
+    private double swLat;
+
+    /** 남서쪽 모서리 경도 (bottom-left) */
+    private double swLng;
+
+    // -------------------------------
+    // 2) Delta 기준 정보
+    // -------------------------------
+
+    /**
+     * 기준 시각
+     * - 클라이언트 입장: "이 시각 이후로 바뀐 것만 보내줘"
+     * - 서버 입장: 이 값을 기준으로 added/updated/removed 계산
+     * - ISO 8601 형식 문자열로 들어오고, 컨트롤러에서 Instant로 변환 가능
+     */
+    private Instant sinceTs;
+
+    /**
+     * 클라이언트가 이미 가지고 있는 마커의 placeId 목록
+     * - 예: ["pb_1", "pb_2", "pb_3"]
+     * - 서버는 이 목록과 현재 상태를 비교해서
+     *   added / updated / removed 를 계산한다.
+     */
+    private List<String> knownIds;
+
+    // -------------------------------
+    // 3) 선택 필터
+    // -------------------------------
+
+    /**
+     * 브랜드 필터 (선택)
+     * - null 또는 빈 문자열("") 이면 전체 브랜드 대상
+     * - "인생네컷" 등 특정 브랜드만 보고 싶을 때 사용
+     */
+    private String brand;
+
+    /**
+     * 클러스터 옵션 (선택)
+     * - 지금 단계에서는 아직 사용하지 않고 무시해도 됨
+     * - 나중에 클러스터링 기능을 붙이고 싶을 때 확장 가능
+     */
+    private Boolean cluster;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/map/dto/ViewportDeltaResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/dto/ViewportDeltaResponse.java
@@ -1,0 +1,49 @@
+package com.nemo.backend.domain.map.dto;
+
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * 뷰포트 증분(Delta) 조회 응답 DTO
+ *
+ * - added   : 새로 생긴 마커(또는 처음 내려가는 마커)
+ * - updated : 기존에 있던 마커 중에서 내용이 바뀐 마커
+ * - removed : 더 이상 이 뷰포트 안에 존재하지 않는 마커 ID
+ * - serverTs: 이번 응답의 기준 시각 (다음 요청의 sinceTs로 사용)
+ */
+@Data
+@Builder
+public class ViewportDeltaResponse {
+
+    /**
+     * 새로 추가된 마커 목록
+     * - 클라이언트가 knownIds로 보내지 않았던 것들 중,
+     *   현재 뷰포트 안에 새로 등장한 마커들
+     */
+    private List<PhotoboothDto> added;
+
+    /**
+     * 업데이트된 마커 목록
+     * - 클라이언트가 이미 알고 있던 ID이긴 하지만,
+     *   좌표/이름/브랜드 등이 변경된 마커들
+     */
+    private List<PhotoboothDto> updated;
+
+    /**
+     * 제거된 마커 ID 목록
+     * - 클라이언트는 알고 있었지만(knownIds에 있었음),
+     *   현재 서버 기준 뷰포트 안에 더 이상 존재하지 않는 ID들
+     * - 프론트에서는 이 ID들을 지도에서 삭제하면 된다.
+     */
+    private List<String> removedIds;
+
+    /**
+     * 서버 응답 시각
+     * - 클라이언트는 이 값을 그대로 저장해 두었다가
+     *   다음 /viewport/delta 요청의 sinceTs로 보내면 된다.
+     */
+    private Instant serverTs;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/map/service/PhotoboothService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/service/PhotoboothService.java
@@ -5,72 +5,139 @@ import com.nemo.backend.domain.map.dto.PhotoboothDto;
 import com.nemo.backend.domain.map.dto.ViewportRequest;
 import com.nemo.backend.domain.map.util.NaverApiClient;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
+/**
+ * 📌 PhotoboothService
+ * ─────────────────────────────────────────────────────────────────────
+ * 1) 클라이언트가 보낸 '현재 지도 뷰포트(화면)' 정보를 받는다.
+ * 2) 뷰포트 중심 좌표를 기준으로 네이버 Reverse Geocoding 호출 → "강남구 역삼동"
+ * 3) 이 지역명을 기반으로 네이버 Local Search(장소 검색) 실행
+ *     예) "강남구 역삼동 인생네컷", "강남구 역삼동 포토부스"
+ * 4) 검색 결과 중 실제 뷰포트 안에 포함되는 포토부스만 필터링
+ * 5) 중복 제거(50m 이내 + 이름 유사)
+ * 6) 거리 기준 정렬
+ * 7) 브랜드 필터 / LIMIT 적용
+ * ─────────────────────────────────────────────────────────────────────
+ */
+
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PhotoboothService {
 
     private final NaverApiClient naverApiClient;
 
-    // ✅ 검색 키워드(브랜드 + 일반 키워드)
+    // 🔍 기본 검색 키워드(브랜드 + 일반 키워드)
     private static final List<String> KEYWORDS = List.of(
             "포토부스", "인생네컷", "하루필름", "포토이즘", "포토시그널", "포토그레이", "돈룩업"
     );
 
-    // ✅ 네이버 Local API 제약: display 최대 5
-    private static final int PAGE_SIZE = 5;
-
-    // ✅ 한 키워드당 최대 페이지 수(너무 많이 긁지 않도록 안전 장치)
-    //   → 4면 최대 20개(5×4), 필요 시 늘리되 429 위험 고려
-    private static final int MAX_PAGES_PER_KEYWORD = 4;
+    private static final int PAGE_SIZE = 5;               // 네이버 LocalSearch 최대 display=5
+    private static final int MAX_PAGES_PER_KEYWORD = 4;   // 한 키워드당 최대 20개 수집
 
     /**
-     * 뷰포트(현재 지도 화면) 안에 있는 포토부스들 반환
+     * 📌 현재 뷰포트 안에 존재하는 포토부스 반환
      */
     public List<PhotoboothDto> getPhotoboothsInViewport(ViewportRequest req) {
 
-        // 1) 키워드별로 '페이지네이션' 하며 안전하게 수집
+        // ────────────────────────────────────────
+        // 1) 뷰포트 중심 좌표 계산
+        // ────────────────────────────────────────
+        double centerLat = (req.getNeLat() + req.getSwLat()) / 2.0;
+        double centerLng = (req.getNeLng() + req.getSwLng()) / 2.0;
+
+        // ────────────────────────────────────────
+        // 2) Reverse Geocoding → "강남구 역삼동" 같이 지역명 얻기
+        // ────────────────────────────────────────
+        Optional<String> regionOpt = naverApiClient.reverseGeocodeToRegion(centerLat, centerLng);
+        String regionName = regionOpt.orElse(null);
+
+        // ⭐ 로그(1) — 요청된 뷰포트 + 중심 + 역지오코딩 결과
+        log.info("[MAP][REQ] ne=({}, {}), sw=({}, {}), center=({}, {}), region='{}'",
+                req.getNeLat(), req.getNeLng(),
+                req.getSwLat(), req.getSwLng(),
+                centerLat, centerLng,
+                regionName
+        );
+
+        // ────────────────────────────────────────
+        // 3) 실제 네이버 검색에 사용할 키워드 구성
+        //    ▷ 위치 기반 정확한 검색을 위해 "지역명 + 키워드" 형태 선호
+        //      예: "강남구 역삼동 인생네컷"
+        // ────────────────────────────────────────
+        List<String> searchKeywords = new ArrayList<>();
+
+        if (regionName != null && !regionName.isBlank()) {
+            for (String base : KEYWORDS) {
+                searchKeywords.add(regionName + " " + base);
+            }
+            // 보조 키워드 하나 더
+            searchKeywords.add(regionName + " 포토부스");
+        } else {
+            // 역지오코딩 실패 시 → 전국 검색 fallback
+            searchKeywords.addAll(KEYWORDS);
+        }
+
+        // ⭐ 로그(2) — 사용된 검색 키워드 목록 출력
+        log.info("[MAP][KEYWORDS] {}", searchKeywords);
+
+        // ────────────────────────────────────────
+        // 4) 네이버 Local Search 호출 (키워드 × 페이지)
+        // ────────────────────────────────────────
         List<Map<String, Object>> raw = new ArrayList<>();
 
-        for (String kw : KEYWORDS) {
+        for (String kw : searchKeywords) {
             int page = 0;
             boolean hasMore = true;
 
             while (hasMore && page < MAX_PAGES_PER_KEYWORD) {
                 page++;
-                // start는 1부터 시작, display=5이면 1,6,11,... 식으로 넘김
+
+                // start는 1부터 시작 (1, 6, 11, 16...)
                 int start = 1 + (page - 1) * PAGE_SIZE;
 
                 Map<String, Object> res = naverApiClient.searchLocal(kw, PAGE_SIZE, start, "random");
                 List<Map<String, Object>> items = extractItems(res);
 
-                // 아이템 없으면 이 키워드는 더 이상 호출 안 함
                 if (items.isEmpty()) {
-                    hasMore = false;
+                    hasMore = false;  // 다음 페이지 없음
                 } else {
                     raw.addAll(items);
-                    // 마지막 페이지(5개 미만 반환)면 다음부터는 중단
-                    if (items.size() < PAGE_SIZE) hasMore = false;
+                    if (items.size() < PAGE_SIZE) hasMore = false; // 마지막 페이지
                 }
             }
         }
 
-        // 2) map → PhotoboothDto (좌표 변환/브랜드 추정/이름 클린업)
+        // ⭐ 로그(3) — 네이버 LocalSearch 결과 총합
+        log.info("[MAP][RAW] totalRawItems={}", raw.size());
+
+        // ────────────────────────────────────────
+        // 5) raw → PhotoboothDto (좌표 변환, 브랜드 추정, HTML 제거)
+        // ────────────────────────────────────────
         List<PhotoboothDto> all = raw.stream()
                 .map(this::toDto)
-                .filter(dto -> dto.getLatitude() != 0 && dto.getLongitude() != 0) // 좌표 없는건 제외
+                .filter(dto -> dto.getLatitude() != 0 && dto.getLongitude() != 0) // 좌표 없는 경우 제외
                 .collect(Collectors.toList());
 
-        // 3) 뷰포트 안에 있는 것만
+        // ────────────────────────────────────────
+        // 6) 실제 뷰포트 안에 포함되는 후보만 필터링
+        // ────────────────────────────────────────
         List<PhotoboothDto> filtered = all.stream()
                 .filter(p -> inViewport(req, p.getLatitude(), p.getLongitude()))
                 .collect(Collectors.toList());
 
-        // 4) 중복 제거: 50m 이내 & 이름 유사(공백 제거 후 포함관계)
+        // ⭐ 로그(4) — 뷰포트 안에 실제로 존재하는 결과 수
+        log.info("[MAP][FILTER] inViewport={}", filtered.size());
+
+        // ────────────────────────────────────────
+        // 7) 중복 제거 (50m 이내 + 이름 유사)
+        //    ▷ 네이버 검색 결과 특성상 동일한 지점이 여러 키워드에서 중복으로 나올 수 있음
+        // ────────────────────────────────────────
         List<PhotoboothDto> deduped = new ArrayList<>();
         for (PhotoboothDto cur : filtered) {
             boolean dup = deduped.stream().anyMatch(x ->
@@ -81,16 +148,21 @@ public class PhotoboothService {
             if (!dup) deduped.add(cur);
         }
 
-        // 5) 뷰포트 중앙과의 거리 계산 → 가까운 순 정렬
-        double centerLat = (req.getNeLat() + req.getSwLat()) / 2.0;
-        double centerLng = (req.getNeLng() + req.getSwLng()) / 2.0;
+        // ⭐ 로그(5) — dedupe 후 결과
+        log.info("[MAP][DEDUP] deduped={}", deduped.size());
 
+
+        // ────────────────────────────────────────
+        // 8) 뷰포트 중심과의 거리 계산 후 오름차순 정렬
+        // ────────────────────────────────────────
         for (PhotoboothDto dto : deduped) {
             dto.setDistanceMeter(distanceMeter(centerLat, centerLng, dto.getLatitude(), dto.getLongitude()));
         }
         deduped.sort(Comparator.comparingInt(PhotoboothDto::getDistanceMeter));
 
-        // 6) 브랜드 필터(선택)
+        // ────────────────────────────────────────
+        // 9) 브랜드 필터 (요청 시)
+        // ────────────────────────────────────────
         if (req.getBrand() != null && !req.getBrand().isBlank()) {
             String want = req.getBrand().trim();
             deduped = deduped.stream()
@@ -98,14 +170,21 @@ public class PhotoboothService {
                     .collect(Collectors.toList());
         }
 
-        // 7) limit 적용 (기본 300)
+        // ────────────────────────────────────────
+        // 10) LIMIT 적용 (기본=300)
+        // ────────────────────────────────────────
         int max = req.getLimit() != null ? Math.max(1, req.getLimit()) : 300;
         if (deduped.size() > max) deduped = deduped.subList(0, max);
+
+        // ⭐ 로그(6) — 최종 반환 개수
+        log.info("[MAP][RETURN] finalCount={}", deduped.size());
 
         return deduped;
     }
 
-    // ─────────────── helpers ───────────────
+    // ───────────────────────────────────────────────
+    // helpers
+    // ───────────────────────────────────────────────
 
     @SuppressWarnings("unchecked")
     private List<Map<String, Object>> extractItems(Map<String, Object> response) {
@@ -117,13 +196,10 @@ public class PhotoboothService {
         return List.of();
     }
 
-    // 네이버 지역검색 아이템 → 우리 PhotoboothDto
+    // 네이버 지역검색 응답 item → PhotoboothDto 변환
     private PhotoboothDto toDto(Map<String, Object> item) {
-        // 좌표: 네이버 Local 응답의 mapx/mapy(문자열 정수, 1e7 스케일) → 경도/위도
         double lon = parseCoord(safeStr(item.get("mapx"))); // 경도
         double lat = parseCoord(safeStr(item.get("mapy"))); // 위도
-
-        // 장소명: <b>태그 제거
         String name = removeHtml(safeStr(item.get("title")));
 
         return PhotoboothDto.builder()
@@ -134,12 +210,11 @@ public class PhotoboothService {
                 .longitude(lon)
                 .roadAddress(safeStr(item.get("roadAddress")))
                 .naverPlaceUrl(safeStr(item.get("link")))
-                .distanceMeter(0) // 나중에 채움
+                .distanceMeter(0)
                 .cluster(false)
                 .build();
     }
 
-    // 문자열 좌표("1269251342") → 126.9251342
     private double parseCoord(String v) {
         if (v == null || v.isBlank()) return 0.0;
         try {
@@ -149,17 +224,16 @@ public class PhotoboothService {
         }
     }
 
-    // '<b>인생네컷</b> 홍대점' → '인생네컷 홍대점'
+    private String safeStr(Object o) {
+        return o == null ? "" : String.valueOf(o);
+    }
+
     private String removeHtml(String s) {
         if (s == null) return "";
         return s.replaceAll("<[^>]*>", "");
     }
 
-    private String safeStr(Object o) {
-        return o == null ? "" : String.valueOf(o);
-    }
-
-    // 간단 브랜드 추정
+    // 간단 브랜드 추정 로직
     private String guessBrand(String name) {
         if (name == null) return "기타";
         if (name.contains("인생네컷")) return "인생네컷";
@@ -177,19 +251,18 @@ public class PhotoboothService {
                 && lng >= r.getSwLng() && lng <= r.getNeLng();
     }
 
-    // 두 좌표 거리(m) — 하버사인
+    // 하버사인 거리(m)
     private int distanceMeter(double lat1, double lng1, double lat2, double lng2) {
-        double R = 6371000; // m
+        double R = 6371000;
         double dLat = Math.toRadians(lat2 - lat1);
         double dLng = Math.toRadians(lng2 - lng1);
         double a = Math.sin(dLat/2) * Math.sin(dLat/2)
                 + Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2))
                 * Math.sin(dLng/2) * Math.sin(dLng/2);
-        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
         return (int) Math.round(R * c);
     }
 
-    // 이름 비교용 핵심 문자열
     private String core(String n) {
         return n == null ? "" : n.replace(" ", "");
     }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: dev
+    active: local
 
   h2:
     console:
@@ -97,3 +97,8 @@ naver:
       endpoint: https://openapi.naver.com/v1/search/local.json
       client-id: ${NAVER_LOCAL_CLIENT_ID}
       client-secret: ${NAVER_LOCAL_CLIENT_SECRET}
+    map:
+      client-id: ${NAVER_MAP_CLIENT_ID}
+      client-secret: ${NAVER_MAP_CLIENT_SECRET}
+    reverse:
+      endpoint: https://maps.apigw.ntruss.com/map-reversegeocode/v2/gc

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,8 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: local
-
+    active: dev
   h2:
     console:
       enabled: true

--- a/frontend/lib/services/map_api.dart
+++ b/frontend/lib/services/map_api.dart
@@ -33,7 +33,14 @@ class MapApi {
         'minAppVersion': '1.0.0',
       };
     }
+
+    // 🔍 로그: map init 호출
+    print('🗺️ [MapApi] GET /api/map/init');
+
     final res = await ApiClient.get('/api/map/init');
+
+    print('🗺️ [MapApi] /api/map/init status=${res.statusCode}');
+
     if (res.statusCode != 200) {
       throw Exception('map init 실패: ${res.statusCode}');
     }
@@ -58,6 +65,12 @@ class MapApi {
       // 현재 뷰포트 중심 계산
       final centerLat = (neLat + swLat) / 2;
       final centerLng = (neLng + swLng) / 2;
+
+      // 🔍 로그: mock 모드에서의 뷰포트 정보
+      print(
+        '🧭 [MapApi-mock] viewport ne=($neLat, $neLng), '
+            'sw=($swLat, $swLng), center=($centerLat, $centerLng), zoom=$zoom',
+      );
 
       return {
         'items': [
@@ -113,6 +126,7 @@ class MapApi {
         'serverTs': DateTime.now().toUtc().toIso8601String(),
       };
     }
+
     final query = <String, String>{
       'neLat': neLat.toString(),
       'neLng': neLng.toString(),
@@ -123,14 +137,39 @@ class MapApi {
       if (limit != null) 'limit': limit.toString(),
       if (cluster != null) 'cluster': cluster.toString(),
     };
+
+    // 🔍 로그: 실제 서버로 보내는 뷰포트/쿼리 정보
+    final centerLat = (neLat + swLat) / 2;
+    final centerLng = (neLng + swLng) / 2;
+    print(
+      '🧭 [MapApi] viewport ne=($neLat, $neLng), '
+          'sw=($swLat, $swLng), center=($centerLat, $centerLng), '
+          'zoom=$zoom, brand=$brand, limit=$limit, cluster=$cluster',
+    );
+    print('🌐 [MapApi] GET /api/map/photobooths/viewport query=$query');
+
     final res = await ApiClient.get(
       '/api/map/photobooths/viewport',
       queryParameters: query,
     );
+
+    print('📡 [MapApi] /api/map/photobooths/viewport status=${res.statusCode}');
+
     if (res.statusCode != 200) {
+      // 에러 바디도 같이 보이게
+      final bodyText = utf8.decode(res.bodyBytes);
+      print('⚠️ [MapApi] viewport 실패 body=$bodyText');
       throw Exception('viewport 실패: ${res.statusCode}');
     }
-    return jsonDecode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+
+    final decoded =
+    jsonDecode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+
+    // 🔍 로그: 응답 items 개수
+    final items = decoded['items'] as List<dynamic>? ?? const [];
+    print('📍 [MapApi] viewport 응답 items=${items.length}개');
+
+    return decoded;
   }
 
   static Future<Map<String, dynamic>> getDelta({
@@ -147,6 +186,9 @@ class MapApi {
       await Future<void>.delayed(
         Duration(milliseconds: AppConstants.simulatedNetworkDelayMs),
       );
+
+      print('🧭 [MapApi-mock] delta sinceTs=$sinceTs, knownIds=${knownIds.length}개');
+
       return {
         'added': [
           {
@@ -180,6 +222,7 @@ class MapApi {
         'serverTs': DateTime.now().toUtc().toIso8601String(),
       };
     }
+
     final body = {
       'neLat': neLat,
       'neLng': neLng,
@@ -190,13 +233,39 @@ class MapApi {
       if (brand != null && brand.isNotEmpty) 'brand': brand,
       if (cluster != null) 'cluster': cluster,
     };
+
+    // 🔍 로그: delta 요청 바디
+    print(
+      '🔁 [MapApi] POST /api/map/photobooths/viewport/delta '
+          'body={ne=($neLat,$neLng), sw=($swLat,$swLng), sinceTs=$sinceTs, '
+          'knownIds=${knownIds.length}, brand=$brand, cluster=$cluster}',
+    );
+
     final res = await ApiClient.post(
       '/api/map/photobooths/viewport/delta',
       body: body,
     );
+
+    print('📡 [MapApi] /api/map/photobooths/viewport/delta status=${res.statusCode}');
+
     if (res.statusCode != 200) {
+      final bodyText = utf8.decode(res.bodyBytes);
+      print('⚠️ [MapApi] delta 실패 body=$bodyText');
       throw Exception('delta 실패: ${res.statusCode}');
     }
-    return jsonDecode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+
+    final decoded =
+    jsonDecode(utf8.decode(res.bodyBytes)) as Map<String, dynamic>;
+
+    // 🔍 로그: delta 응답 요약
+    final added = decoded['added'] as List<dynamic>? ?? const [];
+    final updated = decoded['updated'] as List<dynamic>? ?? const [];
+    final removedIds = decoded['removedIds'] as List<dynamic>? ?? const [];
+    print(
+      '📍 [MapApi] delta 응답: added=${added.length}, '
+          'updated=${updated.length}, removed=${removedIds.length}',
+    );
+
+    return decoded;
   }
 }


### PR DESCRIPTION


---

#  **PR: 지도 뷰포트 검색 + Delta 구조 준비 (Reverse Geocoding 기반)**

## ✨ **요약**

이번 PR은 **지도 기반 포토부스 검색의 핵심 기능**을 완성하고,
추가로 차세대 기능인 **뷰포트 증분 조회(Delta)** 구조를 대비하여
DTO/Service 구조를 정리한 작업입니다.

---

#  **1. 네이버 Reverse Geocoding + 뷰포트 검색 기능 구현**

###  주요 구현 내용

* **Reverse Geocoding 적용**

    * 지도 중심 좌표 → 행정구역명(구/동 단위) 변환
    * 네이버 지도 API 기반

* **지역명 + 키워드 기반 검색**

    * "OO동 인생네컷", "강남구 하루필름" 형태로 Local Search 자동 생성
    * 브랜드 자동 유추 로직 적용

* **뷰포트 필터링 적용**

    * 현재 화면(NE–SW 박스) 안에 있는 포토부스만 최종 리스트에 포함

* **중복 제거 고도화**

    * 50m 거리 기준 + 이름 유사도 비교
    * 2개 이상 겹친 지점 자동 병합

* **네이버 API Client 개선**

    * 캐싱 적용 (URI 기준 메모리 캐시)
    * 429(Too Many Requests) 재시도 로직
    * 예외/실패 처리 강화

* **환경변수 적용**

    * `NAVER_MAP_CLIENT_ID`, `NAVER_MAP_CLIENT_SECRET`
    * `application-local.yml`에서 정상 로딩 확인

* **Flutter 통합 테스트 완료**

    * 실제 지도 화면에 “포토부스 마커” 정상 표시 확인

---

#  **2. Delta 조회 구조 준비(+lastUpdated 도입)**

차후 구현 예정인 `/viewport/delta` API를 위해
기존 구조를 건드리지 않는 선에서 **준비 작업**을 진행함.

###  주요 변경 내용

* **PhotoboothDto에 `lastUpdated` 필드 추가**

    * Delta 비교용 내부 필드
    * `@JsonIgnore` 적용하여 프론트 JSON 응답에는 포함되지 않음

* **클러스터링 기능 제거 방향 정리**

    * 미사용 필드(`cluster`, `count`, `bucketSize`) 정리 또는 TODO 주석 추가

* **Delta 비교 로직 틀 마련**

    * `hasChangedSince()` 메서드 골격 추가
    * “지금은 DB 사용 X이므로 updated는 false” 정책으로 설계 준비

* **PhotoboothService 정리**

    * Delta API 추가 시 그대로 연결될 수 있도록 로직 구조 점검

---

#  **테스트 항목**

### ✔️ 기능 테스트

* 지도 이동/줌 변경 시 정상적으로 포토부스 목록 업데이트됨
* ReverseGeocoding 응답 기반 지역명이 정확히 생성됨
* 빈 검색 결과/중복 결과 모두 정상 처리
* Flutter에서 실제 지도 마커 표시 완료

### ✔️ 회귀 테스트

* 기존 `/viewport` API 동작 문제 없음
* 프론트 JSON 구조 변화 없음 (lastUpdated는 숨김 처리)

---

#  **향후 계획**

* `/viewport/delta` API 개발

    * added/updated/removed 구조 적용
    * Delta 기반 지도 부하 감소 및 부드러운 UX 목표

* 포토부스 DB 저장 여부 논의 후 lastUpdated 실제 활용 여부 확정

    * 저장 가능 시 DB 엔티티 + 초깃값 세팅까지 진행
    * 불가 시 Delta의 updated는 스킵하고 added/removed 중심

---
