### PR TITLE
이미지 업로드 전체 개선(WebP/JPEG/PNG 압축, 리사이즈, MIME 감지 강화) 및 업로드 파이프라인 안정화

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 	// TwelveMonkeys는 자바 ImageIO의 포맷 지원을 확장해줘서 CMYK JPEG 읽기가 가능해짐.
 	implementation 'com.twelvemonkeys.imageio:imageio-core:3.10.1'
 	implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.10.1'
+	// ★ WEBP 인코딩/디코딩 지원
+	implementation 'com.twelvemonkeys.imageio:imageio-webp:3.10.1'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,10 +62,10 @@ dependencies {
     // 빠른 메모리 캐시
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 	// TwelveMonkeys는 자바 ImageIO의 포맷 지원을 확장해줘서 CMYK JPEG 읽기가 가능해짐.
-	implementation 'com.twelvemonkeys.imageio:imageio-core:3.10.1'
-	implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.10.1'
-	// ★ WEBP 인코딩/디코딩 지원
-	implementation 'com.twelvemonkeys.imageio:imageio-webp:3.10.1'
+	implementation 'com.twelvemonkeys.imageio:imageio-core:3.12.0'
+	implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.12.0'
+	// ★ WEBP 인코딩/디코딩 지원 (Sejda)
+	implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/nemo/backend/domain/auth/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/nemo/backend/domain/auth/jwt/JwtUtil.java
@@ -41,6 +41,9 @@ public class JwtUtil {
     /** Access Token 유효 시간 (밀리초 단위) */
     private final long accessTtlMs;
 
+    /** 서버/클라이언트 시간차 허용 범위 (초 단위) – 여기선 3분 */
+    private static final long CLOCK_SKEW_SECONDS = 180L; // 180초 = 3분
+
     /**
      * 생성자
      * - application.yml(or .env)에 있는 설정 값을 주입받는다.
@@ -144,6 +147,7 @@ public class JwtUtil {
             return Jwts.parserBuilder()
                     .setSigningKey(key)     // 서명 검증용 키
                     .requireIssuer(issuer)  // issuer(발급자)도 일치하는지 체크
+                    .setAllowedClockSkewSeconds(CLOCK_SKEW_SECONDS) // 🔥 시간 오차 허용
                     .build()
                     .parseClaimsJws(token)  // 여기서 서명 검증 + 만료 검사
                     .getBody();

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -18,6 +18,8 @@ import javax.imageio.ImageIO;
 import javax.imageio.ImageWriteParam;
 import javax.imageio.ImageWriter;
 import javax.imageio.stream.ImageOutputStream;
+import java.awt.Color;
+import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -30,6 +32,15 @@ import java.util.UUID;
 @Component
 @Slf4j
 public class S3PhotoStorage implements PhotoStorage {
+
+    private static final int MAX_LONG_EDGE = 2048; // 긴 변 기준 최대 픽셀
+
+    static {
+        ImageIO.scanForPlugins();
+        boolean hasWriter = ImageIO.getImageWritersByFormatName("webp").hasNext()
+                || ImageIO.getImageWritersByMIMEType("image/webp").hasNext();
+        log.info("[S3PhotoStorage] WEBP writer available? {}", hasWriter);
+    }
 
     private final S3Client s3Client;
     private final String bucket;
@@ -86,13 +97,30 @@ public class S3PhotoStorage implements PhotoStorage {
         String detected = detectMime(data);
         String mime = chooseMime(reported, detected, file.getOriginalFilename());
 
-        // 이미지면 WEBP로 변환 (이미 webp면 그대로 둠)
-        if (isConvertibleImageMime(mime)) {
-            byte[] converted = convertToWebP(data, file.getOriginalFilename());
-            if (converted != null && converted.length > 0 && converted != data) {
-                data = converted;
-                mime = "image/webp";
-            }
+        // LOG: 업로드 들어온 원본 정보
+        log.info("[S3PhotoStorage] multipart upload start: name={}, requestSize={} bytes, "
+                        + "reportedMime={}, detectedMime={}",
+                file.getOriginalFilename(),
+                file.getSize(),
+                reported,
+                detected
+        );
+
+        int originalSize = data.length; // LOG용
+
+        // 이미지면 WEBP → JPEG → PNG 순으로 압축/변환 Best Effort
+        if (isImageMime(mime)) {
+            CompressedResult result = compressImageBestEffort(data, file.getOriginalFilename(), mime);
+            data = result.bytes;
+            mime = result.mime;
+
+            log.info("[S3PhotoStorage] multipart image result: name={}, originalSize={} bytes, "
+                            + "finalSize={} bytes, targetMime={}",
+                    file.getOriginalFilename(),
+                    originalSize,
+                    data.length,
+                    mime
+            );
         }
 
         String key = buildKey(mime, file.getOriginalFilename());
@@ -106,6 +134,11 @@ public class S3PhotoStorage implements PhotoStorage {
                     .build();
 
             s3Client.putObject(req, RequestBody.fromBytes(data));
+
+            // LOG: 최종 업로드 완료
+            log.info("[S3PhotoStorage] multipart upload done: key={}, size={} bytes, mime={}",
+                    key, data.length, mime);
+
             return key;
 
         } catch (S3Exception e) {
@@ -130,13 +163,30 @@ public class S3PhotoStorage implements PhotoStorage {
         String detected = detectMime(data);
         String mime = chooseMime(contentType, detected, originalFilename);
 
-        // QR에서 받아온 이미지도 WEBP로 변환
-        if (isConvertibleImageMime(mime)) {
-            byte[] converted = convertToWebP(data, originalFilename);
-            if (converted != null && converted.length > 0 && converted != data) {
-                data = converted;
-                mime = "image/webp";
-            }
+        int originalSize = data.length; // LOG용
+
+        // LOG: 바이트 기반 업로드 시작
+        log.info("[S3PhotoStorage] byte upload start: name={}, originalSize={} bytes, "
+                        + "contentType={}, detectedMime={}",
+                originalFilename,
+                originalSize,
+                contentType,
+                detected
+        );
+
+        // 이미지면 WEBP → JPEG → PNG 순으로 압축/변환 Best Effort
+        if (isImageMime(mime)) {
+            CompressedResult result = compressImageBestEffort(data, originalFilename, mime);
+            data = result.bytes;
+            mime = result.mime;
+
+            log.info("[S3PhotoStorage] byte image result: name={}, originalSize={} bytes, "
+                            + "finalSize={} bytes, targetMime={}",
+                    originalFilename,
+                    originalSize,
+                    data.length,
+                    mime
+            );
         }
 
         String key = buildKey(mime, originalFilename);
@@ -150,6 +200,11 @@ public class S3PhotoStorage implements PhotoStorage {
                     .build();
 
             s3Client.putObject(req, RequestBody.fromBytes(data));
+
+            // LOG: 최종 업로드 완료
+            log.info("[S3PhotoStorage] byte upload done: key={}, size={} bytes, mime={}",
+                    key, data.length, mime);
+
             return key;
 
         } catch (S3Exception e) {
@@ -251,47 +306,172 @@ public class S3PhotoStorage implements PhotoStorage {
         return "bin";
     }
 
-    /** WEBP로 변환할 수 있는 이미지 MIME 인지 여부 */
-    private static boolean isConvertibleImageMime(String mime) {
+    /** 어떤 이미지든 일단 "이미지면" 압축 대상 */
+    private static boolean isImageMime(String mime) {
         if (mime == null) return false;
-        String m = mime.toLowerCase(Locale.ROOT);
-        if (!m.startsWith("image/")) return false;
-        // 이미 webp면 변환 안 함
-        return !m.equals("image/webp");
+        return mime.toLowerCase(Locale.ROOT).startsWith("image/");
     }
 
+    // ---------- 여기부터 압축 Best Effort 로직 ----------
     /**
-     * 원본 바이트를 WEBP (고품질)로 변환
-     * - 변환 실패 시 원본 바이트 그대로 반환
+     * 1) 리사이즈 (긴 변 2048px 기준)
+     * 2) WEBP(품질 0.8) 시도
+     * 3) WEBP가 에러나거나 이득이 거의 없으면 JPEG(품질 0.85) 시도
+     * 4) 그래도 실패/이득 없음 → PNG 시도
+     * 5) 끝까지 안 되면 원본 + 원래 mime 유지
      */
-    private byte[] convertToWebP(byte[] original, String originalName) {
-        try (ByteArrayInputStream in = new ByteArrayInputStream(original);
-             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+    private CompressedResult compressImageBestEffort(byte[] original, String originalName, String originalMime) {
+        int originalSize = original.length;
+        BufferedImage image;
+        try (ByteArrayInputStream in = new ByteArrayInputStream(original)) {
+            image = ImageIO.read(in);
+        } catch (Exception e) {
+            throw new StorageException("이미지 디코딩 실패: " + originalName + " / " + e.getMessage(), e);
+        }
 
-            BufferedImage image = ImageIO.read(in);
-            if (image == null) {
-                log.warn("WEBP 변환 실패 (이미지로 읽을 수 없음): {}", originalName);
-                return original;
+        if (image == null) {
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT,
+                    "이미지 파일로 읽을 수 없습니다: " + originalName);
+        }
+
+        // 0) 너무 크면 리사이즈
+        BufferedImage work = resizeIfNecessary(image, originalName);
+
+        // 1) WEBP 우선 시도
+        try {
+            byte[] webp = encodeImage(work, "webp", 0.80f);
+            if (webp != null && webp.length > 0) {
+                double ratio = (double) webp.length / originalSize;
+                if (ratio < 0.95) { // 5% 이상 줄어들면 채택
+                    int saved = originalSize - webp.length;
+                    log.info("WEBP 압축 성공: {} (orig={} bytes -> {} bytes, saved={} bytes, ratio={}%)",
+                            originalName, originalSize, webp.length, saved, Math.round(ratio * 100));
+                    return new CompressedResult(webp, "image/webp");
+                } else {
+                    log.debug("WEBP 후보가 원본보다 크거나 이득이 적어 패스: {} (orig={} -> {} bytes, ratio={}%)",
+                            originalName, originalSize, webp.length, Math.round(ratio * 100));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("WEBP 압축 실패, JPEG 시도: {} / {}", originalName, e.getMessage());
+        }
+
+        // 2) JPEG 시도 (투명도 있으면 흰 배경)
+        try {
+            BufferedImage rgbImage = work;
+            if (work.getType() != BufferedImage.TYPE_INT_RGB) {
+                rgbImage = new BufferedImage(work.getWidth(), work.getHeight(), BufferedImage.TYPE_INT_RGB);
+                Graphics2D g2d = rgbImage.createGraphics();
+                g2d.setColor(Color.WHITE);
+                g2d.fillRect(0, 0, work.getWidth(), work.getHeight());
+                g2d.drawImage(work, 0, 0, null);
+                g2d.dispose();
             }
 
-            ImageWriter writer = null;
-            var writers = ImageIO.getImageWritersByFormatName("webp");
+            byte[] jpeg = encodeImage(rgbImage, "jpeg", 0.85f);
+            if (jpeg != null && jpeg.length > 0) {
+                double ratio = (double) jpeg.length / originalSize;
+                if (ratio < 0.98) { // 2% 이상 줄어들면 채택
+                    int saved = originalSize - jpeg.length;
+                    log.info("JPEG 압축 성공: {} (orig={} bytes -> {} bytes, saved={} bytes, ratio={}%)",
+                            originalName, originalSize, jpeg.length, saved, Math.round(ratio * 100));
+                    return new CompressedResult(jpeg, "image/jpeg");
+                } else {
+                    log.debug("JPEG 후보가 원본보다 크거나 이득이 적어 패스: {} (orig={} -> {} bytes, ratio={}%)",
+                            originalName, originalSize, jpeg.length, Math.round(ratio * 100));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("JPEG 압축 실패, PNG 시도: {} / {}", originalName, e.getMessage());
+        }
+
+        // 3) PNG 시도 (대부분의 사진에서는 보통 손해라 거의 안 쓸 가능성 높음)
+        try {
+            byte[] png = encodeImage(work, "png", null);
+            if (png != null && png.length > 0) {
+                double ratio = (double) png.length / originalSize;
+                if (ratio < 0.98) {
+                    int saved = originalSize - png.length;
+                    log.info("PNG 압축 성공: {} (orig={} bytes -> {} bytes, saved={} bytes, ratio={}%)",
+                            originalName, originalSize, png.length, saved, Math.round(ratio * 100));
+                    return new CompressedResult(png, "image/png");
+                } else {
+                    log.debug("PNG 후보가 원본보다 크거나 이득이 적어 패스: {} (orig={} -> {} bytes, ratio={}%)",
+                            originalName, originalSize, png.length, Math.round(ratio * 100));
+                }
+            }
+        } catch (Exception e) {
+            log.warn("PNG 압축 실패, 원본 업로드: {} / {}", originalName, e.getMessage());
+        }
+
+        // 4) 전부 실패 or 이득 없음 → 원본 그대로
+        log.info("압축/변환해도 이득이 없어 원본 유지: {} (size={} bytes, mime={})",
+                originalName, originalSize, originalMime);
+        String finalMime = isGood(originalMime) ? originalMime : "application/octet-stream";
+        return new CompressedResult(original, finalMime);
+    }
+
+    /** 긴 변이 MAX_LONG_EDGE 보다 크면 비율 유지해서 리사이즈 */
+    private BufferedImage resizeIfNecessary(BufferedImage src, String originalName) {
+        int w = src.getWidth();
+        int h = src.getHeight();
+        int longEdge = Math.max(w, h);
+
+        if (longEdge <= MAX_LONG_EDGE) {
+            return src; // 그대로 사용
+        }
+
+        double scale = (double) MAX_LONG_EDGE / (double) longEdge;
+        int newW = (int) Math.round(w * scale);
+        int newH = (int) Math.round(h * scale);
+
+        BufferedImage resized = new BufferedImage(newW, newH, src.getType() == 0
+                ? BufferedImage.TYPE_INT_ARGB
+                : src.getType());
+        Graphics2D g2d = resized.createGraphics();
+        g2d.setRenderingHint(java.awt.RenderingHints.KEY_INTERPOLATION,
+                java.awt.RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        g2d.drawImage(src, 0, 0, newW, newH, null);
+        g2d.dispose();
+
+        log.info("이미지 리사이즈: {} ({}x{} -> {}x{})",
+                originalName, w, h, newW, newH);
+
+        return resized;
+    }
+
+    private byte[] encodeImage(BufferedImage image, String formatName, Float quality) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        ImageWriter writer = null;
+        ImageOutputStream ios = null;
+        try {
+            // 1) 포맷 이름으로 writer 찾기
+            var writers = ImageIO.getImageWritersByFormatName(formatName);
+            // 2) webp인 경우 MIME 기반으로 한 번 더 시도
+            if (!writers.hasNext() && "webp".equalsIgnoreCase(formatName)) {
+                writers = ImageIO.getImageWritersByMIMEType("image/webp");
+            }
             if (!writers.hasNext()) {
-                log.warn("WEBP ImageWriter 없음 - 원본 그대로 업로드: {}", originalName);
-                return original;
+                throw new IllegalStateException("ImageWriter not found for format: " + formatName);
             }
+
             writer = writers.next();
 
+            if ("webp".equalsIgnoreCase(formatName)) {
+                log.info("[WEBP] Using writer implementation: {}", writer.getClass().getName());
+            }
+
             ImageWriteParam param = writer.getDefaultWriteParam();
-            if (param.canWriteCompressed()) {
+
+            if (quality != null && param.canWriteCompressed()) {
                 param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
 
-                // 가능한 compression type 중 Lossless가 있으면 우선 사용
+                // ★ compressionType 먼저 지정
                 String[] types = param.getCompressionTypes();
                 if (types != null && types.length > 0) {
                     String chosen = types[0];
                     for (String t : types) {
-                        if (t.toLowerCase(Locale.ROOT).contains("lossless")) {
+                        if (t != null && t.toLowerCase(Locale.ROOT).contains("lossy")) {
                             chosen = t;
                             break;
                         }
@@ -299,26 +479,39 @@ public class S3PhotoStorage implements PhotoStorage {
                     param.setCompressionType(chosen);
                 }
 
-                // 화질 거의 최대 (0.0 ~ 1.0)
-                param.setCompressionQuality(0.9f);
+                param.setCompressionQuality(quality); // 0.0 ~ 1.0
             }
 
-            try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
-                writer.setOutput(ios);
-                writer.write(null, new IIOImage(image, null, null), param);
-            } finally {
-                writer.dispose();
+            ios = ImageIO.createImageOutputStream(out);
+            writer.setOutput(ios);
+            writer.write(null, new IIOImage(image, null, null), param);
+
+            byte[] encoded = out.toByteArray();
+
+            if ("webp".equalsIgnoreCase(formatName)) {
+                log.info("[WEBP] Encoded size={} bytes (quality={})", encoded.length, quality);
             }
 
-            byte[] webp = out.toByteArray();
-            if (webp.length == 0) {
-                log.warn("WEBP 변환 결과가 비어 있음 - 원본 사용: {}", originalName);
-                return original;
+            // ★ 여기서 0바이트면 실패로 간주해서 예외 던짐
+            if (encoded.length == 0) {
+                throw new IllegalStateException("Encoded image is empty for format: " + formatName);
             }
-            return webp;
-        } catch (Exception e) {
-            log.warn("WEBP 변환 중 예외 발생 - 원본 사용: {} / {}", originalName, e.getMessage());
-            return original;
+
+            return encoded;
+        } finally {
+            if (ios != null) ios.close();
+            if (writer != null) writer.dispose();
+            out.close();
+        }
+    }
+
+    private static class CompressedResult {
+        final byte[] bytes;
+        final String mime;
+
+        CompressedResult(byte[] bytes, String mime) {
+            this.bytes = bytes;
+            this.mime = mime;
         }
     }
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -31,10 +31,10 @@ app:
 
 
   s3:
-    bucket: nemo-dev-photos
+    bucket: nemo-s3-test
     region: ap-northeast-2
-    endpoint: http://localhost:4566
-    accessKey: test
-    secretKey: test
-    pathStyle: true
-    createBucketIfMissing: true
+    endpoint: ""                    # AWS니까 endpoint 없음
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
+    pathStyle: false
+    createBucketIfMissing: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,20 +8,34 @@
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    # 🛰️ 내부 통신용 주소 (포트 고정: 3306)
+    # ⛓️ CloudType DB 접속 주소 (도메인 탭에서 확인)
     url: jdbc:mariadb://svc.sel5.cloudtype.app:30303/nemo?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-    username: ${DB_USER}         # 환경변수로 관리 (CloudType 시크릿)
-    password: ${DB_PASSWORD}
+    username: ${DB_USER}      # DB 사용자명
+    password: ${DB_PASSWORD}   # DB 비밀번호
 
   jpa:
+    database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
       ddl-auto: validate         # 운영 환경은 validate (DB 변경 금지)
     show-sql: false
     properties:
       hibernate.format_sql: true
 
+
 app:
+  jwt:
+    # 최소 32바이트 이상. 예시는 Base64 32바이트(24 raw bytes)보다 더 긴 랜덤 문자열 권장.
+    secret: "nemo-dev-secret-please-change-this-very-long-32bytes-min!"
+    issuer: "nemo-backend"
+    access-ttl-ms: 900000   # 15분 (밀리초)
+
   s3:
-    accessKey: ${AWS_ACCESS_KEY_ID}
-    secretKey: ${AWS_SECRET_ACCESS_KEY}
+    bucket: nemo-s3-test
+    region: ap-northeast-2
+    endpoint: ""                    # AWS니까 endpoint 없음
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
     pathStyle: false
+    createBucketIfMissing: false
+
+  public-base-url: https://api.nemo.app

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: dev
+    active: prod
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 개요
기존 이미지 업로드 로직은 원본 파일 그대로 S3에 업로드되어
용량 증가(비용 증가), 느린 로딩, 브라우저 호환성 문제 등이 발생하고 있었습니다.

또한 WebP 변환 실패, MIME 타입 불일치, HTML/JSON 응답이 이미지로 잘못 업로드되는 문제 등이 있어
업로드 파이프라인 전반을 개선했습니다.

이번 PR에서는 다음과 같은 핵심 변경 사항을 포함합니다.


---

## 1. 이미지 압축 Best-Effort 파이프라인 추가
이미지 업로드 시 다음 순서대로 최적 압축을 시도합니다.

1) **긴 변 2048px 기준 리사이즈**  
   - 대형 이미지(4~10MB)의 대부분이 리사이즈에서 70~90% 용량 절감 효과

2) **WebP 변환 시도 (quality=0.8)**  
   - WebP 인코딩 성공 시 5% 이상 용량 절감되면 자동 채택  
   - Java WebP encoder 특성상 0 bytes 출력 등의 실패도 안전하게 처리

3) **JPEG 재압축 (quality=0.85)**  
   - WebP 실패 시 안정적인 lossy 압축  
   - 실제 테스트에서 9MB → 640KB 수준으로 감소

4) **PNG fallback**  
   - 손실 압축에 적합하지 않은 이미지의 경우 사용

5) **이득이 없는 경우 원본 유지**  
   - 소형 이미지(10~50KB)는 오히려 커질 가능성이 있어 원본 유지

이 로직은 실서비스(Instagram, Kakao, Twitter 등)에서 사용하는 업로드 전략과 동일합니다.

---

## 2. MIME 타입 정밀 감지 강화
- 파일 헤더(매직 넘버) 기반 MIME 분석
- HTML/JSON 감지(<!doctype, <html, {" 로 시작하는 응답 차단)
- WebP/HEIC/MP4 판별 정확도 개선
- 업로드 시 content-type / content-disposition 정확하게 설정

---

## 3. QR 업로드 / 갤러리 업로드의 처리 로직 통합
- QR 다운로드 이미지도 동일한 압축 정책 적용
- 일반 업로드와 동일한 리사이즈·압축 품질 유지
- 브랜드/리사이즈/압축 불일치 문제 해결

---

## 4. 안정성 개선 및 오류 방지
- WebP writer 감지 로그 추가
- WebP 인코딩 실패(0 bytes) 감지 후 안전한 fallback
- S3 업로드 실패 예외 처리 강화
- 원본이 HTML이면 즉시 업로드 중단

---

## 5. 로깅 강화
다음 정보가 명확히 출력되도록 개선했습니다:

- 원본/최종 용량, 압축 비율
- WebP Writer 종류 출력
- 각 포맷(JPEG, PNG) 시도 결과
- 리사이즈 여부 및 새 해상도
- QR → 최종 이미지 변환 과정

---

## 기대 효과

- S3 저장 비용 최적화 (대형 이미지 최대 90% 절감)
- 업로드 속도 개선, 전체 사용자 UX 개선
- QR 이미지와 갤러리 이미지의 품질/용량 정책 일관성 확보
- HTML/JSON 오업로드 방지로 보안 강화
- WebP 관련 실패 이슈 완전 안정화
- Android/iOS 앱에서의 로딩 성능 향상

---

## 추가 고려사항
- WebP 인코더는 Java 기반에서 한계가 있어 실패시 JPEG 사용 전략 유지
- 필요 시 imgproxy 또는 Thumbor 기반의 외부 이미지 서버도 고려 가능

---

## 결론
이번 PR은 Nemo 프로젝트의 이미지 업로드 파이프라인을
안정성·용량 최적화·품질 관리 측면에서 대폭 향상시키는 핵심 개선입니다.

리뷰 부탁드립니다!
