### PR TITLE
앨범-사진 N:N 구조 전환 및 썸네일/QR 처리 로직 전면 개선

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/entity/Album.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/entity/Album.java
@@ -6,6 +6,7 @@ import com.nemo.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -32,7 +33,12 @@ public class Album extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // 앨범에 포함된 사진
-    @OneToMany(mappedBy = "album")
-    private List<Photo> photos;
+    // ✅ 앨범에 포함된 사진 (N:N)
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "album_photos",
+            joinColumns = @JoinColumn(name = "album_id"),
+            inverseJoinColumns = @JoinColumn(name = "photo_id")
+    )
+    private List<Photo> photos = new ArrayList<>();
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoResponseDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoResponseDto.java
@@ -12,13 +12,11 @@ import java.time.LocalDateTime;
 public class PhotoResponseDto {
     private Long id;
     private Long userId;
-    private Long albumId;
     private String imageUrl;
     private String thumbnailUrl;
     private String brand;
     private LocalDateTime takenAt;
     private String location;        // 명세: location 문자열 하나
-    private String qrHash;
     private LocalDateTime createdAt;
     private boolean favorite;
     private String memo;
@@ -26,13 +24,11 @@ public class PhotoResponseDto {
     public PhotoResponseDto(Photo photo) {
         this.id = photo.getId();
         this.userId = photo.getUserId();
-        this.albumId = photo.getAlbumId();
         this.imageUrl = photo.getImageUrl();
         this.thumbnailUrl = photo.getThumbnailUrl();
         this.brand = photo.getBrand();
         this.takenAt = photo.getTakenAt();
         this.location = photo.getLocation();
-        this.qrHash = photo.getQrHash();
         this.createdAt = photo.getCreatedAt();
         this.favorite = Boolean.TRUE.equals(photo.getFavorite());
         this.memo = photo.getMemo();
@@ -40,13 +36,11 @@ public class PhotoResponseDto {
 
     public Long getId() { return id; }
     public Long getUserId() { return userId; }
-    public Long getAlbumId() { return albumId; }
     public String getImageUrl() { return imageUrl; }
     public String getThumbnailUrl() { return thumbnailUrl; }
     public String getBrand() { return brand; }
     public LocalDateTime getTakenAt() { return takenAt; }
     public String getLocation() { return location; }
-    public String getQrHash() { return qrHash; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public boolean isFavorite() { return favorite; }
     public String getMemo() { return memo; }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
@@ -1,19 +1,16 @@
 // backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
 package com.nemo.backend.domain.photo.entity;
 
-import com.nemo.backend.domain.album.entity.Album;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 
 /**
  * 사진 1장(레코드) + 연계 정보 엔티티.
- * QR 해시(qrHash)로 중복 업로드를 방지한다.
+ * (QR 중복 해시 사용 X)
  */
 @Entity
-@Table(name = "photos", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"qrHash"})
-})
+@Table(name = "photos")
 public class Photo {
 
     @Id
@@ -21,10 +18,6 @@ public class Photo {
     private Long id;
 
     private Long userId;
-
-    /** 앨범 연관관계 */
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Album album;
 
     @Column(nullable = false)
     private String imageUrl;
@@ -39,9 +32,6 @@ public class Photo {
     private String location;
 
     private String brand;
-
-    @Column(unique = true)
-    private String qrHash;
 
     /** 즐겨찾기 여부 (기본 false) */
     @Column(name = "favorite")
@@ -59,19 +49,15 @@ public class Photo {
 
     public Photo(
             Long userId,
-            Album album,
             String imageUrl,
             String thumbnailUrl,
-            String qrHash,
             String brand,
             LocalDateTime takenAt,
             String location
     ) {
         this.userId = userId;
-        this.album = album;
         this.imageUrl = imageUrl;
         this.thumbnailUrl = thumbnailUrl;
-        this.qrHash = qrHash;
         this.brand = brand;
         this.takenAt = takenAt;
         this.location = location;
@@ -82,12 +68,6 @@ public class Photo {
 
     public Long getUserId() { return userId; }
     public void setUserId(Long userId) { this.userId = userId; }
-
-    /** 기존 코드 호환용 편의 메서드 */
-    public Long getAlbumId() { return album != null ? album.getId() : null; }
-
-    public Album getAlbum() { return album; }
-    public void setAlbum(Album album) { this.album = album; }
 
     public String getImageUrl() { return imageUrl; }
     public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
@@ -103,9 +83,6 @@ public class Photo {
 
     public String getBrand() { return brand; }
     public void setBrand(String brand) { this.brand = brand; }
-
-    public String getQrHash() { return qrHash; }
-    public void setQrHash(String qrHash) { this.qrHash = qrHash; }
 
     public Boolean getFavorite() { return favorite; }
     public void setFavorite(Boolean favorite) { this.favorite = favorite; }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -11,15 +11,10 @@ import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    Optional<Photo> findByQrHash(String qrHash);
-
     Page<Photo> findByUserIdAndDeletedIsFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     // ✅ 즐겨찾기만 필터
     Page<Photo> findByUserIdAndDeletedIsFalseAndFavoriteTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
-
-    // ✅ 앨범 내 사진들 (삭제 안 된 것만) 최신순
-    List<Photo> findByAlbum_IdAndDeletedIsFalseOrderByCreatedAtDesc(Long albumId);
 
     // ✅ 특정 사진이 살아있는지 검사할 때 사용
     Optional<Photo> findByIdAndDeletedIsFalse(Long id);

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -92,12 +92,8 @@ public class PhotoServiceImpl implements PhotoService {
             throw new ApiException(ErrorCode.INVALID_ARGUMENT, "image 또는 qrUrl/qrCode 중 하나는 필수입니다.");
         }
 
-        // QR 중복 차단
-        if (qrUrlOrPayload != null && !qrUrlOrPayload.isBlank()) {
-            String qrHash = sha256Hex(qrUrlOrPayload);
-            photoRepository.findByQrHash(qrHash)
-                    .ifPresent(p -> { throw new ApiException(ErrorCode.CONFLICT, "이미 업로드된 QR입니다."); });
-        }
+        // 🔥 QR 중복 차단 로직 제거됨
+        //    → 동일 QR이라도 매번 새로운 Photo를 생성
 
         String storedImage;
         String storedThumb;
@@ -137,15 +133,12 @@ public class PhotoServiceImpl implements PhotoService {
         }
         if (takenAt == null) takenAt = LocalDateTime.now();
 
-        String qrHash = (qrUrlOrPayload != null && !qrUrlOrPayload.isBlank()) ? sha256Hex(qrUrlOrPayload) : null;
-
+        // ✅ QR 해시(qrHash) 저장 제거: 더 이상 중복 체크/보관 안 함
         // ✅ videoUrl 필드 제거: DB에는 image / thumbnail / location 등만 저장
         Photo photo = new Photo(
                 userId,
-                null,
                 storedImage,
                 storedThumb,
-                qrHash,
                 brand,
                 takenAt,
                 location


### PR DESCRIPTION
## 📌 개요
이번 PR은 사진/앨범 기능의 핵심 구조를 현행 명세에 맞게 전면 개편한 내용입니다.
특히 "한 사진이 여러 앨범에 포함될 수 있어야 한다"는 요구사항과
"QR 중복 업로드 제거"가 기능 전체에 영향을 주기 때문에 관련 로직을 전체적으로 수정했습니다.

---

## 🔧 주요 변경 내용

### 1) Photo ↔ Album 관계를 N:N 구조로 변경
- Photo 엔티티에서 album 필드 및 관련 getter/setter 제거
- Album 엔티티에서 photos를 `@ManyToMany` + `album_photos` 조인 테이블로 관리
- AlbumService의 add/removePhotos가 해당 앨범에서만 사진을 추가/제거하도록 변경
- 이제 하나의 사진이 여러 앨범에 정상적으로 포함될 수 있음

---

### 2) 앨범 썸네일 시스템 전면 개선
- 사진 삭제 시 썸네일이 해당 사진일 경우 자동으로 재선택
- 사진이 0장인 앨범은 썸네일이 null로 표시되도록 수정 (빈 앨범 처리)
- coverPhotoId로 지정한 썸네일이 앨범 생성 시 제대로 적용되지 않던 문제 해결
- 기존 썸네일이 유효하지 않은 경우 자동으로 새로 설정되도록 로직 강화

---

### 3) photoCount 불일치 문제 해결
- 목록/상세 모두 deleted=false 사진만 포함하도록 통일
- 앨범에서 사진 삭제 시 count가 즉시 반영되도록 수정

---

### 4) QR 중복 업로드 기능 제거
- 더 이상 QR 해시 기반 중복 체크 사용하지 않음
- qrHash 컬럼/필드/DTO/Repository/업로드 로직 모두 삭제
- 동일 QR도 새로운 사진으로 업로드 가능하도록 변경
- uploadHybrid에서 QR 관련 예외 및 sha256 처리 로직 제거

---

### 5) 기타 정리
- 사용되지 않는 메서드 제거
- PhotoServiceImpl와 AlbumService 중심으로 복잡한 legacy 로직 정리

---

## ✨ 기대 효과
- 앨범/사진 동작이 명세와 완전히 일치
- 사진 추가/삭제/조회에서 예상치 못한 부작용 제거
- UI에서 나타나던 photoCount 및 썸네일 오류 해결
- QR 업로드 흐름 단순화 및 안정화
- 유지보수성/확장성 크게 향상

---

## 🔍 테스트 항목
- 사진 업로드 (QR/갤러리)
- 사진 다중 앨범 포함
- 앨범 생성 + coverPhotoId 지정
- 앨범 사진 추가/삭제
- 앨범 목록 photoCount 반영 여부
- 썸네일 자동갱신 / 빈 앨범 처리
- QR 중복 업로드 정상 동작

---

필요하다면 DB 마이그레이션 SQL(`album_photos` 생성, qr_hash 컬럼 제거)도 함께 제공 가능합니다.
