### PR TITLE
사진 다운로드 기능 및 앨범 기반 선택 다운로드 권한 검증 로직 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -64,6 +64,8 @@ dependencies {
 	// TwelveMonkeys는 자바 ImageIO의 포맷 지원을 확장해줘서 CMYK JPEG 읽기가 가능해짐.
 	implementation 'com.twelvemonkeys.imageio:imageio-core:3.10.1'
 	implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.10.1'
+	// ★ WEBP 인코딩/디코딩 지원
+	implementation 'com.twelvemonkeys.imageio:imageio-webp:3.10.1'
 }
 
 tasks.named('test') {

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -62,10 +62,10 @@ dependencies {
     // 빠른 메모리 캐시
     implementation("com.github.ben-manes.caffeine:caffeine:3.1.8")
 	// TwelveMonkeys는 자바 ImageIO의 포맷 지원을 확장해줘서 CMYK JPEG 읽기가 가능해짐.
-	implementation 'com.twelvemonkeys.imageio:imageio-core:3.10.1'
-	implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.10.1'
-	// ★ WEBP 인코딩/디코딩 지원
-	implementation 'com.twelvemonkeys.imageio:imageio-webp:3.10.1'
+	implementation 'com.twelvemonkeys.imageio:imageio-core:3.12.0'
+	implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.12.0'
+	// ★ WEBP 인코딩/디코딩 지원 (Sejda)
+	implementation 'org.sejda.imageio:webp-imageio:0.1.6'
 }
 
 tasks.named('test') {

--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -264,4 +264,15 @@ public class AlbumController {
         AlbumFavoriteResponse resp = albumService.setFavorite(userId, albumId, false);
         return ResponseEntity.ok(resp);
     }
+
+    // ✅ 11) GET /api/albums/{albumId}/download-urls : 앨범 전체 사진 다운로드 URL 목록
+    @GetMapping("/{albumId}/download-urls")
+    public ResponseEntity<AlbumDownloadUrlsResponse> getAlbumDownloadUrls(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @PathVariable Long albumId
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+        AlbumDownloadUrlsResponse resp = albumService.getAlbumDownloadUrls(userId, albumId);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
@@ -1,0 +1,16 @@
+// com.nemo.backend.domain.album.dto.AlbumDownloadUrlsResponse
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AlbumDownloadUrlsResponse {
+    private Long albumId;
+    private String albumTitle;
+    private Integer photoCount;
+    private List<AlbumPhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
@@ -1,0 +1,15 @@
+// com.nemo.backend.domain.album.dto.AlbumPhotoDownloadUrlDto
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlbumPhotoDownloadUrlDto {
+    private Long photoId;
+    private Integer sequence;
+    private String downloadUrl;
+    private String filename;
+    private Long fileSize;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/entity/Album.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/entity/Album.java
@@ -6,6 +6,7 @@ import com.nemo.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -32,7 +33,12 @@ public class Album extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    // 앨범에 포함된 사진
-    @OneToMany(mappedBy = "album")
-    private List<Photo> photos;
+    // ✅ 앨범에 포함된 사진 (N:N)
+    @ManyToMany(fetch = FetchType.LAZY)
+    @JoinTable(
+            name = "album_photos",
+            joinColumns = @JoinColumn(name = "album_id"),
+            inverseJoinColumns = @JoinColumn(name = "photo_id")
+    )
+    private List<Photo> photos = new ArrayList<>();
 }

--- a/backend/src/main/java/com/nemo/backend/domain/auth/jwt/JwtUtil.java
+++ b/backend/src/main/java/com/nemo/backend/domain/auth/jwt/JwtUtil.java
@@ -41,6 +41,9 @@ public class JwtUtil {
     /** Access Token 유효 시간 (밀리초 단위) */
     private final long accessTtlMs;
 
+    /** 서버/클라이언트 시간차 허용 범위 (초 단위) – 여기선 3분 */
+    private static final long CLOCK_SKEW_SECONDS = 180L; // 180초 = 3분
+
     /**
      * 생성자
      * - application.yml(or .env)에 있는 설정 값을 주입받는다.
@@ -144,6 +147,7 @@ public class JwtUtil {
             return Jwts.parserBuilder()
                     .setSigningKey(key)     // 서명 검증용 키
                     .requireIssuer(issuer)  // issuer(발급자)도 일치하는지 체크
+                    .setAllowedClockSkewSeconds(CLOCK_SKEW_SECONDS) // 🔥 시간 오차 허용
                     .build()
                     .parseClaimsJws(token)  // 여기서 서명 검증 + 만료 검사
                     .getBody();

--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
@@ -277,6 +277,7 @@ public class PhotoController {
     public ResponseEntity<PagedResponse<PhotoListItemDto>> list(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @RequestParam(value = "favorite", required = false) Boolean favorite,
+            @RequestParam(value = "brand", required = false) String brand,   // ✅ 추가
             @RequestParam(value = "tag", required = false) String tag,
             @RequestParam(value = "sort", required = false, defaultValue = "takenAt,desc") String sortBy,
             @RequestParam(value = "page", required = false, defaultValue = "0") Integer page,
@@ -300,7 +301,9 @@ public class PhotoController {
         }
 
         Pageable pageable = PageRequest.of(page, size, sort);
-        var pageDto = photoService.list(userId, pageable, favorite);
+
+        // ✅ brand / tag 까지 전달
+        var pageDto = photoService.list(userId, pageable, favorite, brand, tag);
         DateTimeFormatter ISO = DateTimeFormatter.ISO_LOCAL_DATE_TIME;
 
         List<PhotoListItemDto> items = pageDto.map(p -> PhotoListItemDto.builder()

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
@@ -1,0 +1,14 @@
+// com.nemo.backend.domain.photo.dto.PhotoDownloadUrlDto
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PhotoDownloadUrlDto {
+    private Long photoId;
+    private String downloadUrl;
+    private String filename;   // 선택
+    private Long fileSize;     // 선택 (byte)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoResponseDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoResponseDto.java
@@ -12,13 +12,11 @@ import java.time.LocalDateTime;
 public class PhotoResponseDto {
     private Long id;
     private Long userId;
-    private Long albumId;
     private String imageUrl;
     private String thumbnailUrl;
     private String brand;
     private LocalDateTime takenAt;
     private String location;        // 명세: location 문자열 하나
-    private String qrHash;
     private LocalDateTime createdAt;
     private boolean favorite;
     private String memo;
@@ -26,13 +24,11 @@ public class PhotoResponseDto {
     public PhotoResponseDto(Photo photo) {
         this.id = photo.getId();
         this.userId = photo.getUserId();
-        this.albumId = photo.getAlbumId();
         this.imageUrl = photo.getImageUrl();
         this.thumbnailUrl = photo.getThumbnailUrl();
         this.brand = photo.getBrand();
         this.takenAt = photo.getTakenAt();
         this.location = photo.getLocation();
-        this.qrHash = photo.getQrHash();
         this.createdAt = photo.getCreatedAt();
         this.favorite = Boolean.TRUE.equals(photo.getFavorite());
         this.memo = photo.getMemo();
@@ -40,13 +36,11 @@ public class PhotoResponseDto {
 
     public Long getId() { return id; }
     public Long getUserId() { return userId; }
-    public Long getAlbumId() { return albumId; }
     public String getImageUrl() { return imageUrl; }
     public String getThumbnailUrl() { return thumbnailUrl; }
     public String getBrand() { return brand; }
     public LocalDateTime getTakenAt() { return takenAt; }
     public String getLocation() { return location; }
-    public String getQrHash() { return qrHash; }
     public LocalDateTime getCreatedAt() { return createdAt; }
     public boolean isFavorite() { return favorite; }
     public String getMemo() { return memo; }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
@@ -1,0 +1,13 @@
+// com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SelectedPhotosDownloadUrlsResponse {
+    private List<PhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
@@ -1,19 +1,16 @@
 // backend/src/main/java/com/nemo/backend/domain/photo/entity/Photo.java
 package com.nemo.backend.domain.photo.entity;
 
-import com.nemo.backend.domain.album.entity.Album;
 import jakarta.persistence.*;
 
 import java.time.LocalDateTime;
 
 /**
  * 사진 1장(레코드) + 연계 정보 엔티티.
- * QR 해시(qrHash)로 중복 업로드를 방지한다.
+ * (QR 중복 해시 사용 X)
  */
 @Entity
-@Table(name = "photos", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"qrHash"})
-})
+@Table(name = "photos")
 public class Photo {
 
     @Id
@@ -21,10 +18,6 @@ public class Photo {
     private Long id;
 
     private Long userId;
-
-    /** 앨범 연관관계 */
-    @ManyToOne(fetch = FetchType.LAZY)
-    private Album album;
 
     @Column(nullable = false)
     private String imageUrl;
@@ -39,9 +32,6 @@ public class Photo {
     private String location;
 
     private String brand;
-
-    @Column(unique = true)
-    private String qrHash;
 
     /** 즐겨찾기 여부 (기본 false) */
     @Column(name = "favorite")
@@ -59,19 +49,15 @@ public class Photo {
 
     public Photo(
             Long userId,
-            Album album,
             String imageUrl,
             String thumbnailUrl,
-            String qrHash,
             String brand,
             LocalDateTime takenAt,
             String location
     ) {
         this.userId = userId;
-        this.album = album;
         this.imageUrl = imageUrl;
         this.thumbnailUrl = thumbnailUrl;
-        this.qrHash = qrHash;
         this.brand = brand;
         this.takenAt = takenAt;
         this.location = location;
@@ -82,12 +68,6 @@ public class Photo {
 
     public Long getUserId() { return userId; }
     public void setUserId(Long userId) { this.userId = userId; }
-
-    /** 기존 코드 호환용 편의 메서드 */
-    public Long getAlbumId() { return album != null ? album.getId() : null; }
-
-    public Album getAlbum() { return album; }
-    public void setAlbum(Album album) { this.album = album; }
 
     public String getImageUrl() { return imageUrl; }
     public void setImageUrl(String imageUrl) { this.imageUrl = imageUrl; }
@@ -103,9 +83,6 @@ public class Photo {
 
     public String getBrand() { return brand; }
     public void setBrand(String brand) { this.brand = brand; }
-
-    public String getQrHash() { return qrHash; }
-    public void setQrHash(String qrHash) { this.qrHash = qrHash; }
 
     public Boolean getFavorite() { return favorite; }
     public void setFavorite(Boolean favorite) { this.favorite = favorite; }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -11,15 +11,10 @@ import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    Optional<Photo> findByQrHash(String qrHash);
-
     Page<Photo> findByUserIdAndDeletedIsFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
 
     // ✅ 즐겨찾기만 필터
     Page<Photo> findByUserIdAndDeletedIsFalseAndFavoriteTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
-
-    // ✅ 앨범 내 사진들 (삭제 안 된 것만) 최신순
-    List<Photo> findByAlbum_IdAndDeletedIsFalseOrderByCreatedAtDesc(Long albumId);
 
     // ✅ 특정 사진이 살아있는지 검사할 때 사용
     Optional<Photo> findByIdAndDeletedIsFalse(Long id);

--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -5,20 +5,35 @@ import com.nemo.backend.domain.photo.entity.Photo;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
-    Page<Photo> findByUserIdAndDeletedIsFalseOrderByCreatedAtDesc(Long userId, Pageable pageable);
-
-    // ✅ 즐겨찾기만 필터
-    Page<Photo> findByUserIdAndDeletedIsFalseAndFavoriteTrueOrderByCreatedAtDesc(Long userId, Pageable pageable);
+    // ✅ 사진 목록 조회용 동적 필터 (favorite / brand / tag)
+    @Query("""
+        SELECT p
+        FROM Photo p
+        WHERE p.userId = :userId
+          AND p.deleted = false
+          AND (:favorite IS NULL OR p.favorite = :favorite)
+          AND (:brand IS NULL OR p.brand = :brand)
+          AND (:tag IS NULL OR p.memo LIKE %:tag%)
+        """)
+    Page<Photo> findForList(
+            @Param("userId") Long userId,
+            @Param("favorite") Boolean favorite,
+            @Param("brand") String brand,
+            @Param("tag") String tag,
+            Pageable pageable
+    );
 
     // ✅ 특정 사진이 살아있는지 검사할 때 사용
     Optional<Photo> findByIdAndDeletedIsFalse(Long id);
 
-    // ✅ 타임라인용: 촬영일시 기준 내림차순 전체 조회
+    // ✅ 타임라인용: 촬영일시 기준 내림차순 전체 조회 (그대로 유지)
     List<Photo> findByUserIdAndDeletedIsFalseOrderByTakenAtDesc(Long userId);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -22,10 +22,23 @@ public interface PhotoService {
             String memo
     );
 
-    Page<PhotoResponseDto> list(Long userId, Pageable pageable, Boolean favorite);
+    // ✅ 브랜드/태그까지 포함한 메인 시그니처
+    Page<PhotoResponseDto> list(
+            Long userId,
+            Pageable pageable,
+            Boolean favorite,
+            String brand,
+            String tag
+    );
 
+    // ✅ 기존 시그니처 유지용 오버로드 (favorite만)
+    default Page<PhotoResponseDto> list(Long userId, Pageable pageable, Boolean favorite) {
+        return list(userId, pageable, favorite, null, null);
+    }
+
+    // ✅ 기존 기본 오버로드
     default Page<PhotoResponseDto> list(Long userId, Pageable pageable) {
-        return list(userId, pageable, null);
+        return list(userId, pageable, null, null, null);
     }
 
     void delete(Long userId, Long photoId);

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -2,11 +2,13 @@
 package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
+import com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PhotoService {
 
@@ -55,4 +57,7 @@ public interface PhotoService {
     );
 
     boolean toggleFavorite(Long userId, Long photoId);
+
+    // ✅ 선택된 사진들에 대한 다운로드 URL 목록 조회
+    SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -92,12 +92,8 @@ public class PhotoServiceImpl implements PhotoService {
             throw new ApiException(ErrorCode.INVALID_ARGUMENT, "image 또는 qrUrl/qrCode 중 하나는 필수입니다.");
         }
 
-        // QR 중복 차단
-        if (qrUrlOrPayload != null && !qrUrlOrPayload.isBlank()) {
-            String qrHash = sha256Hex(qrUrlOrPayload);
-            photoRepository.findByQrHash(qrHash)
-                    .ifPresent(p -> { throw new ApiException(ErrorCode.CONFLICT, "이미 업로드된 QR입니다."); });
-        }
+        // 🔥 QR 중복 차단 로직 제거됨
+        //    → 동일 QR이라도 매번 새로운 Photo를 생성
 
         String storedImage;
         String storedThumb;
@@ -137,15 +133,12 @@ public class PhotoServiceImpl implements PhotoService {
         }
         if (takenAt == null) takenAt = LocalDateTime.now();
 
-        String qrHash = (qrUrlOrPayload != null && !qrUrlOrPayload.isBlank()) ? sha256Hex(qrUrlOrPayload) : null;
-
+        // ✅ QR 해시(qrHash) 저장 제거: 더 이상 중복 체크/보관 안 함
         // ✅ videoUrl 필드 제거: DB에는 image / thumbnail / location 등만 저장
         Photo photo = new Photo(
                 userId,
-                null,
                 storedImage,
                 storedThumb,
-                qrHash,
                 brand,
                 takenAt,
                 location

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoStorage.java
@@ -1,4 +1,4 @@
-// com.nemo.backend.domain.photo.service.PhotoStorage
+// backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoStorage.java
 package com.nemo.backend.domain.photo.service;
 
 import org.springframework.web.multipart.MultipartFile;
@@ -9,4 +9,7 @@ public interface PhotoStorage {
 
     /** URL 크롤링 등으로 확보한 바이트를 직접 저장하고 키(경로)를 반환 */
     String storeBytes(byte[] data, String originalFilename, String contentType) throws Exception;
+
+    /** S3 등에 저장된 객체를 삭제 */
+    void delete(String key) throws Exception;
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -132,6 +132,7 @@ public class S3PhotoStorage implements PhotoStorage {
         }
     }
 
+
     private String buildKey(String mime, String originalName) {
         String ext = extensionForMime(mime, originalName);
         String today = LocalDate.now().toString();
@@ -225,5 +226,27 @@ public class S3PhotoStorage implements PhotoStorage {
     public static class StorageException extends RuntimeException {
         public StorageException(String msg) { super(msg); }
         public StorageException(String msg, Throwable cause) { super(msg, cause); }
+    }
+
+    /** S3 객체 삭제 */
+    @Override
+    public void delete(String key) {
+        if (key == null || key.isBlank()) return;
+
+        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
+
+        try {
+            DeleteObjectRequest req = DeleteObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normalizedKey)
+                    .build();
+
+            s3Client.deleteObject(req);
+
+        } catch (NoSuchKeyException e) {
+            // 이미 안 존재하는 경우는 무시
+        } catch (S3Exception | SdkClientException e) {
+            throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
+        }
     }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -249,4 +249,25 @@ public class S3PhotoStorage implements PhotoStorage {
             throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
         }
     }
+
+    /** S3 객체 크기 조회 (byte 단위) – presigned URL/다운로드 목록에서 용량 보여줄 때 사용 */
+    public Long getObjectSize(String key) {
+        if (key == null || key.isBlank()) return null;
+
+        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
+
+        try {
+            HeadObjectRequest head = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normalizedKey)
+                    .build();
+            HeadObjectResponse res = s3Client.headObject(head);
+            return res.contentLength();
+        } catch (NoSuchKeyException e) {
+            // 없는 경우는 그냥 null
+            return null;
+        } catch (S3Exception | SdkClientException e) {
+            throw new StorageException("S3 객체 정보 조회 실패: " + e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -3,6 +3,7 @@ package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
@@ -12,6 +13,14 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 
+import javax.imageio.IIOImage;
+import javax.imageio.ImageIO;
+import javax.imageio.ImageWriteParam;
+import javax.imageio.ImageWriter;
+import javax.imageio.stream.ImageOutputStream;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.util.Locale;
@@ -19,6 +28,7 @@ import java.util.UUID;
 
 @Primary
 @Component
+@Slf4j
 public class S3PhotoStorage implements PhotoStorage {
 
     private final S3Client s3Client;
@@ -76,6 +86,15 @@ public class S3PhotoStorage implements PhotoStorage {
         String detected = detectMime(data);
         String mime = chooseMime(reported, detected, file.getOriginalFilename());
 
+        // 이미지면 WEBP로 변환 (이미 webp면 그대로 둠)
+        if (isConvertibleImageMime(mime)) {
+            byte[] converted = convertToWebP(data, file.getOriginalFilename());
+            if (converted != null && converted.length > 0 && converted != data) {
+                data = converted;
+                mime = "image/webp";
+            }
+        }
+
         String key = buildKey(mime, file.getOriginalFilename());
 
         try {
@@ -110,6 +129,16 @@ public class S3PhotoStorage implements PhotoStorage {
 
         String detected = detectMime(data);
         String mime = chooseMime(contentType, detected, originalFilename);
+
+        // QR에서 받아온 이미지도 WEBP로 변환
+        if (isConvertibleImageMime(mime)) {
+            byte[] converted = convertToWebP(data, originalFilename);
+            if (converted != null && converted.length > 0 && converted != data) {
+                data = converted;
+                mime = "image/webp";
+            }
+        }
+
         String key = buildKey(mime, originalFilename);
 
         try {
@@ -221,6 +250,77 @@ public class S3PhotoStorage implements PhotoStorage {
         String guessed = guessFromName(originalName);
         if (guessed != null) return extensionForMime(guessed, null);
         return "bin";
+    }
+
+    /** WEBP로 변환할 수 있는 이미지 MIME 인지 여부 */
+    private static boolean isConvertibleImageMime(String mime) {
+        if (mime == null) return false;
+        String m = mime.toLowerCase(Locale.ROOT);
+        if (!m.startsWith("image/")) return false;
+        // 이미 webp면 변환 안 함
+        return !m.equals("image/webp");
+    }
+
+    /**
+     * 원본 바이트를 WEBP (고품질)로 변환
+     * - 변환 실패 시 원본 바이트 그대로 반환
+     */
+    private byte[] convertToWebP(byte[] original, String originalName) {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(original);
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+
+            BufferedImage image = ImageIO.read(in);
+            if (image == null) {
+                log.warn("WEBP 변환 실패 (이미지로 읽을 수 없음): {}", originalName);
+                return original;
+            }
+
+            ImageWriter writer = null;
+            var writers = ImageIO.getImageWritersByFormatName("webp");
+            if (!writers.hasNext()) {
+                log.warn("WEBP ImageWriter 없음 - 원본 그대로 업로드: {}", originalName);
+                return original;
+            }
+            writer = writers.next();
+
+            ImageWriteParam param = writer.getDefaultWriteParam();
+            if (param.canWriteCompressed()) {
+                param.setCompressionMode(ImageWriteParam.MODE_EXPLICIT);
+
+                // 가능한 compression type 중 Lossless가 있으면 우선 사용
+                String[] types = param.getCompressionTypes();
+                if (types != null && types.length > 0) {
+                    String chosen = types[0];
+                    for (String t : types) {
+                        if (t.toLowerCase(Locale.ROOT).contains("lossless")) {
+                            chosen = t;
+                            break;
+                        }
+                    }
+                    param.setCompressionType(chosen);
+                }
+
+                // 화질 거의 최대 (0.0 ~ 1.0)
+                param.setCompressionQuality(0.9f);
+            }
+
+            try (ImageOutputStream ios = ImageIO.createImageOutputStream(out)) {
+                writer.setOutput(ios);
+                writer.write(null, new IIOImage(image, null, null), param);
+            } finally {
+                writer.dispose();
+            }
+
+            byte[] webp = out.toByteArray();
+            if (webp.length == 0) {
+                log.warn("WEBP 변환 결과가 비어 있음 - 원본 사용: {}", originalName);
+                return original;
+            }
+            return webp;
+        } catch (Exception e) {
+            log.warn("WEBP 변환 중 예외 발생 - 원본 사용: {} / {}", originalName, e.getMessage());
+            return original;
+        }
     }
 
     public static class StorageException extends RuntimeException {

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -56,6 +56,18 @@ public enum ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
 
+    // 사진/앨범 도메인
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_NOT_FOUND", "사진을 찾을 수 없습니다."),
+    NO_DOWNLOADABLE_PHOTOS(HttpStatus.NOT_FOUND, "NO_DOWNLOADABLE_PHOTOS", "다운로드 가능한 사진이 없습니다."), // ⬅️ 추가
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_NOT_FOUND", "앨범을 찾을 수 없습니다."),
+    ALBUM_SHARE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_SHARE_NOT_FOUND", "공유 앨범 정보를 찾을 수 없습니다."),
+    ALBUM_FORBIDDEN(HttpStatus.FORBIDDEN, "ALBUM_FORBIDDEN", "해당 앨범에 대한 권한이 없습니다."),
+    ALBUM_SHARE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ALBUM_SHARE_ALREADY_EXISTS", "이미 초대된 사용자입니다."),
+    ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE", "자기 자신의 역할은 수정할 수 없습니다."),
+    ALBUM_SHARE_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_OWNER_CANNOT_LEAVE", "소유자는 앨범을 탈퇴할 수 없습니다."),
+    ALBUM_SHARE_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_ALREADY_ACCEPTED", "이미 수락된 초대입니다."),
+
+
     // 캘린더 타임라인 코드
     INVALID_QUERY(HttpStatus.BAD_REQUEST, "INVALID_QUERY", "year와 month 파라미터는 필수입니다.");
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -31,7 +31,7 @@ app:
 
 
   s3:
-    bucket: nemo-s3-test
+    bucket: nemo-s3-prod
     region: ap-northeast-2
     endpoint: ""                    # AWS니까 endpoint 없음
     accessKey: ${AWS_ACCESS_KEY}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -31,10 +31,10 @@ app:
 
 
   s3:
-    bucket: nemo-dev-photos
+    bucket: nemo-s3-test
     region: ap-northeast-2
-    endpoint: http://localhost:4566
-    accessKey: test
-    secretKey: test
-    pathStyle: true
-    createBucketIfMissing: true
+    endpoint: ""                    # AWS니까 endpoint 없음
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
+    pathStyle: false
+    createBucketIfMissing: false

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -8,20 +8,34 @@
 spring:
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    # 🛰️ 내부 통신용 주소 (포트 고정: 3306)
+    # ⛓️ CloudType DB 접속 주소 (도메인 탭에서 확인)
     url: jdbc:mariadb://svc.sel5.cloudtype.app:30303/nemo?useUnicode=true&characterEncoding=UTF-8&serverTimezone=Asia/Seoul
-    username: ${DB_USER}         # 환경변수로 관리 (CloudType 시크릿)
-    password: ${DB_PASSWORD}
+    username: ${DB_USER}      # DB 사용자명
+    password: ${DB_PASSWORD}   # DB 비밀번호
 
   jpa:
+    database-platform: org.hibernate.dialect.MariaDBDialect
     hibernate:
       ddl-auto: validate         # 운영 환경은 validate (DB 변경 금지)
     show-sql: false
     properties:
       hibernate.format_sql: true
 
+
 app:
+  jwt:
+    # 최소 32바이트 이상. 예시는 Base64 32바이트(24 raw bytes)보다 더 긴 랜덤 문자열 권장.
+    secret: "nemo-dev-secret-please-change-this-very-long-32bytes-min!"
+    issuer: "nemo-backend"
+    access-ttl-ms: 900000   # 15분 (밀리초)
+
   s3:
-    accessKey: ${AWS_ACCESS_KEY_ID}
-    secretKey: ${AWS_SECRET_ACCESS_KEY}
+    bucket: nemo-s3-test
+    region: ap-northeast-2
+    endpoint: ""                    # AWS니까 endpoint 없음
+    accessKey: ${AWS_ACCESS_KEY}
+    secretKey: ${AWS_SECRET_KEY}
     pathStyle: false
+    createBucketIfMissing: false
+
+  public-base-url: https://api.nemo.app

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: dev
+    active: prod
   h2:
     console:
       enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: prod
+    active: local
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 개요
사진 다운로드 기능과 선택 다운로드 기능을 전체 명세에 맞추어 구현하였으며,
별도의 다운로드 엔드포인트를 추가하지 않고 기존 `/api/photos` 범위 안에서 처리하도록 구성했습니다.
앨범 기반 권한 검증도 통합해 안전한 다운로드가 가능하도록 했습니다.

---

## 주요 구현 사항

### 1) 단일 사진 다운로드 기능 추가
- `GET /api/photos/{photoId}/download`
- 백엔드가 직접 파일을 반환하지 않고 **302 Redirect → 실제 URL(S3 또는 LocalStack)** 로 이동
- 프론트에서는 단순히 해당 URL을 호출하면 다운로드 처리됨

### 2) 선택 다운로드 API 추가
- `POST /api/photos/download-urls`
- 입력된 photoId 목록에 대해 **다운로드 가능한 URL만 반환**
- 프론트는 이 URL 리스트를 가지고 여러 장을 동시에 다운로드 가능

---

## 권한 검증 로직 (DOWNLOAD 권한 통합)

### ✅ 다운로드 가능한 기준
- 사진을 소유한 본인(OWNER)
- 사진이 포함된 **앨범 중 한 곳이라도**
  - OWNER
  - CO_OWNER
  - EDITOR
  - VIEWER
  권한이 있으면 다운로드 가능

### ⛔ 다운로드 불가한 경우
- 사진이 포함된 앨범 중 **전부 접근 권한이 존재하지 않는 경우**
- OWNER/공유 멤버가 아닌 사용자가 photoId만 임의로 지정하는 경우

---

## Swagger 테스트 결과
- 단일 다운로드는 Swagger에서 이미지 바로 표시됨
- 선택 다운로드는 URL 리스트 정상 반환됨
- 실제 파일 여러 개 다운로드는 프론트에서 반복 호출로 정상 동작 예정

---

## 기타 수정사항
- publicBaseUrl 정규화
- Viewer 이상 다운로드 허용 로직 구현
- 앨범 다운로드용 별도 endpoint는 명세에 따라 생성하지 않음

---

## 결론
명세 요구사항에 맞추어 **“단일 다운로드 + 선택 다운로드 + 앨범 권한 기반 보호”**를 완성했습니다.
프론트에서는 반환된 URL 목록으로 멀티 다운로드 처리를 하면 됩니다.
