### PR TITLE
포토그레이 QR 지원 추가 및 이미지 추출 안정화

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -264,4 +264,15 @@ public class AlbumController {
         AlbumFavoriteResponse resp = albumService.setFavorite(userId, albumId, false);
         return ResponseEntity.ok(resp);
     }
+
+    // ✅ 11) GET /api/albums/{albumId}/download-urls : 앨범 전체 사진 다운로드 URL 목록
+    @GetMapping("/{albumId}/download-urls")
+    public ResponseEntity<AlbumDownloadUrlsResponse> getAlbumDownloadUrls(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @PathVariable Long albumId
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+        AlbumDownloadUrlsResponse resp = albumService.getAlbumDownloadUrls(userId, albumId);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
@@ -1,0 +1,16 @@
+// com.nemo.backend.domain.album.dto.AlbumDownloadUrlsResponse
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AlbumDownloadUrlsResponse {
+    private Long albumId;
+    private String albumTitle;
+    private Integer photoCount;
+    private List<AlbumPhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
@@ -1,0 +1,15 @@
+// com.nemo.backend.domain.album.dto.AlbumPhotoDownloadUrlDto
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlbumPhotoDownloadUrlDto {
+    private Long photoId;
+    private Integer sequence;
+    private String downloadUrl;
+    private String filename;
+    private Long fileSize;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
@@ -1,0 +1,14 @@
+// com.nemo.backend.domain.photo.dto.PhotoDownloadUrlDto
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PhotoDownloadUrlDto {
+    private Long photoId;
+    private String downloadUrl;
+    private String filename;   // 선택
+    private Long fileSize;     // 선택 (byte)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
@@ -1,0 +1,13 @@
+// com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SelectedPhotosDownloadUrlsResponse {
+    private List<PhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -2,11 +2,13 @@
 package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
+import com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PhotoService {
 
@@ -55,4 +57,7 @@ public interface PhotoService {
     );
 
     boolean toggleFavorite(Long userId, Long photoId);
+
+    // ✅ 선택된 사진들에 대한 다운로드 URL 목록 조회
+    SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -249,4 +249,25 @@ public class S3PhotoStorage implements PhotoStorage {
             throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
         }
     }
+
+    /** S3 객체 크기 조회 (byte 단위) – presigned URL/다운로드 목록에서 용량 보여줄 때 사용 */
+    public Long getObjectSize(String key) {
+        if (key == null || key.isBlank()) return null;
+
+        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
+
+        try {
+            HeadObjectRequest head = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normalizedKey)
+                    .build();
+            HeadObjectResponse res = s3Client.headObject(head);
+            return res.contentLength();
+        } catch (NoSuchKeyException e) {
+            // 없는 경우는 그냥 null
+            return null;
+        } catch (S3Exception | SdkClientException e) {
+            throw new StorageException("S3 객체 정보 조회 실패: " + e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -56,6 +56,18 @@ public enum ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
 
+    // 사진/앨범 도메인
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_NOT_FOUND", "사진을 찾을 수 없습니다."),
+    NO_DOWNLOADABLE_PHOTOS(HttpStatus.NOT_FOUND, "NO_DOWNLOADABLE_PHOTOS", "다운로드 가능한 사진이 없습니다."), // ⬅️ 추가
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_NOT_FOUND", "앨범을 찾을 수 없습니다."),
+    ALBUM_SHARE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_SHARE_NOT_FOUND", "공유 앨범 정보를 찾을 수 없습니다."),
+    ALBUM_FORBIDDEN(HttpStatus.FORBIDDEN, "ALBUM_FORBIDDEN", "해당 앨범에 대한 권한이 없습니다."),
+    ALBUM_SHARE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ALBUM_SHARE_ALREADY_EXISTS", "이미 초대된 사용자입니다."),
+    ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE", "자기 자신의 역할은 수정할 수 없습니다."),
+    ALBUM_SHARE_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_OWNER_CANNOT_LEAVE", "소유자는 앨범을 탈퇴할 수 없습니다."),
+    ALBUM_SHARE_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_ALREADY_ACCEPTED", "이미 수락된 초대입니다."),
+
+
     // 캘린더 타임라인 코드
     INVALID_QUERY(HttpStatus.BAD_REQUEST, "INVALID_QUERY", "year와 month 파라미터는 필수입니다.");
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ spring:
       hibernate.format_sql: true
 
 app:
-  public-base-url: http://10.0.2.2:8080
+  public-base-url: http://localhost:8080
 
   jwt:
     # 최소 32바이트 이상. 예시는 Base64 32바이트(24 raw bytes)보다 더 긴 랜덤 문자열 권장.
@@ -31,7 +31,7 @@ app:
 
 
   s3:
-    bucket: nemo-s3-test
+    bucket: nemo-s3-prod
     region: ap-northeast-2
     endpoint: ""                    # AWS니까 endpoint 없음
     accessKey: ${AWS_ACCESS_KEY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: prod
+    active: dev
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 주요 변경 사항

### 1. 포토그레이(Photogray) QR 완전 지원
- `pgshort.aprd.io` → `photogray-download.aprd.io?id=...` 패턴을 인식하여
  HTML 파싱 없이 id 값을 직접 base64 디코딩하여 sessionId 추출.
- `sessionId` 기반으로 `pg-qr-resource.aprd.io/{sessionId}/image.jpg` 및 `video.mp4`를
  직접 호출해 사진/영상 다운로드 가능하도록 구현.
- 이미지 다운로드 버튼을 누르지 않아도 서버에서 image.jpg 생성 및 저장 가능.

### 2. Content-Type 무시하고 이미지 바이트 기반 판별
- Photogray 서버는 image.jpg를 `binary/octet-stream` 으로 반환하는 문제가 있어
  MIME 타입 체크 대신 실제 바이트 기반으로 JPG/PNG/WEBP 등을 판별하도록 변경.
- `ensureValidImageBytes`, `sniffContentType` 로직을 활용해 자동 감지 후 S3 저장.

### 3. 기존 인생네컷(life4cut) QR 로직과 공존
- 기존 인생네컷 전용 `resolveLife4cutNextUrl`, HTML 파서, JSON 스캔 등 기능 그대로 유지.
- Photogray와 Life4cut 모두 정확하게 브랜드 자동 판별하도록 `inferBrand` 보강.

### 4. 브랜드 자동 세팅 개선
- QR URL을 기반으로 아래 2개 브랜드 자동 인식:
  - `life4cut`   → "인생네컷"
  - `pgshort`, `pg-qr-resource`, `photogray` → "포토그레이"
- 브랜드 미지정 상태에서 업로드 시 자동으로 브랜드 저장.

### 5. 안정성 개선
- 이미지/영상 URL 미발견 오류 감소.
- Photogray direct image fetch 실패 시 graceful fallback 적용.
- QR 중복 체크 제거된 버전과 정상 연동.

## 영향 범위
- PhotoServiceImpl QR 업로드 기능 전체 안정성 향상.
- 포토그레이 스티커/네컷 사진 자동 인식 및 업로드 정상 작동 확인.
- 인생네컷은 기존처럼 문제 없이 동작.

## 테스트 완료
- 인생네컷 QR (`api.life4cut.net/...`) 정상동작 확인.
- 포토그레이 QR (`pgshort.aprd.io/...`) 정상적으로 image.jpg 자동 추출 확인.
- 이미지 Content-Type이 octet-stream인 경우도 문제 없이 저장됨.
