### PR TITLE
앨범 썸네일 개선 및 공유 권한·즐겨찾기 로직 수정

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -264,4 +264,15 @@ public class AlbumController {
         AlbumFavoriteResponse resp = albumService.setFavorite(userId, albumId, false);
         return ResponseEntity.ok(resp);
     }
+
+    // ✅ 11) GET /api/albums/{albumId}/download-urls : 앨범 전체 사진 다운로드 URL 목록
+    @GetMapping("/{albumId}/download-urls")
+    public ResponseEntity<AlbumDownloadUrlsResponse> getAlbumDownloadUrls(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @PathVariable Long albumId
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+        AlbumDownloadUrlsResponse resp = albumService.getAlbumDownloadUrls(userId, albumId);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -213,35 +213,38 @@ public class AlbumController {
     public ResponseEntity<AlbumThumbnailResponse> updateThumbnailFromGallery(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long albumId,
-            @RequestBody AlbumThumbnailSelectRequest req
+            @RequestBody(required = false) AlbumThumbnailSelectRequest req   // ✅ optional
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
+        Long photoId = (req != null ? req.getPhotoId() : null);  // ✅ null 허용
         AlbumThumbnailResponse resp =
-                albumService.updateThumbnail(userId, albumId, req.getPhotoId(), null);
+                albumService.updateThumbnail(userId, albumId, photoId, null);
 
         return ResponseEntity.ok(resp);
     }
 
-    // 8-2) POST /api/albums/{albumId}/thumbnail (multipart/form-data)
+
+    // 8-2) POST /api/albums/{albumId}/thumbnail (Multipart, 파일 업로드)
     @PostMapping(
             value = "/{albumId}/thumbnail",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<AlbumThumbnailResponse> updateThumbnail(
+    public ResponseEntity<AlbumThumbnailResponse> updateThumbnailFromFile(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long albumId,
-            @RequestPart(value = "photoId", required = false) Long photoId,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @RequestPart(value = "file", required = false) MultipartFile file   // ✅ optional
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         AlbumThumbnailResponse resp =
-                albumService.updateThumbnail(userId, albumId, photoId, file);
+                albumService.updateThumbnail(userId, albumId, null, file);
 
         return ResponseEntity.ok(resp);
     }
+
+
 
     // 9) POST /api/albums/{albumId}/favorite : 앨범 즐겨찾기 추가
     @PostMapping("/{albumId}/favorite")

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
@@ -1,0 +1,16 @@
+// com.nemo.backend.domain.album.dto.AlbumDownloadUrlsResponse
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AlbumDownloadUrlsResponse {
+    private Long albumId;
+    private String albumTitle;
+    private Integer photoCount;
+    private List<AlbumPhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
@@ -1,0 +1,15 @@
+// com.nemo.backend.domain.album.dto.AlbumPhotoDownloadUrlDto
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlbumPhotoDownloadUrlDto {
+    private Long photoId;
+    private Integer sequence;
+    private String downloadUrl;
+    private String filename;
+    private Long fileSize;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
@@ -22,6 +22,8 @@ public interface AlbumShareRepository extends JpaRepository<AlbumShare, Long> {
     // ✅ 강퇴된 사용자 재초대/재활성화를 위해 active 여부와 상관없이 조회
     Optional<AlbumShare> findByAlbumIdAndUserId(Long albumId, Long userId);
 
-    // 이미 네가 추가해둔 메서드(필요하면 유지)
     Optional<AlbumShare> findByAlbumIdAndUserIdAndActiveTrue(Long albumId, Long userId);
+
+    // ✅ 앨범별 ACCEPTED 멤버만 조회 (공유 멤버 목록용)
+    List<AlbumShare> findByAlbumIdAndStatusAndActiveTrue(Long albumId, Status status);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
@@ -1,0 +1,14 @@
+// com.nemo.backend.domain.photo.dto.PhotoDownloadUrlDto
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PhotoDownloadUrlDto {
+    private Long photoId;
+    private String downloadUrl;
+    private String filename;   // 선택
+    private Long fileSize;     // 선택 (byte)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
@@ -1,0 +1,13 @@
+// com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SelectedPhotosDownloadUrlsResponse {
+    private List<PhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -2,11 +2,13 @@
 package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
+import com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PhotoService {
 
@@ -55,4 +57,7 @@ public interface PhotoService {
     );
 
     boolean toggleFavorite(Long userId, Long photoId);
+
+    // ✅ 선택된 사진들에 대한 다운로드 URL 목록 조회
+    SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -249,4 +249,25 @@ public class S3PhotoStorage implements PhotoStorage {
             throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
         }
     }
+
+    /** S3 객체 크기 조회 (byte 단위) – presigned URL/다운로드 목록에서 용량 보여줄 때 사용 */
+    public Long getObjectSize(String key) {
+        if (key == null || key.isBlank()) return null;
+
+        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
+
+        try {
+            HeadObjectRequest head = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normalizedKey)
+                    .build();
+            HeadObjectResponse res = s3Client.headObject(head);
+            return res.contentLength();
+        } catch (NoSuchKeyException e) {
+            // 없는 경우는 그냥 null
+            return null;
+        } catch (S3Exception | SdkClientException e) {
+            throw new StorageException("S3 객체 정보 조회 실패: " + e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -56,6 +56,18 @@ public enum ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
 
+    // 사진/앨범 도메인
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_NOT_FOUND", "사진을 찾을 수 없습니다."),
+    NO_DOWNLOADABLE_PHOTOS(HttpStatus.NOT_FOUND, "NO_DOWNLOADABLE_PHOTOS", "다운로드 가능한 사진이 없습니다."), // ⬅️ 추가
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_NOT_FOUND", "앨범을 찾을 수 없습니다."),
+    ALBUM_SHARE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_SHARE_NOT_FOUND", "공유 앨범 정보를 찾을 수 없습니다."),
+    ALBUM_FORBIDDEN(HttpStatus.FORBIDDEN, "ALBUM_FORBIDDEN", "해당 앨범에 대한 권한이 없습니다."),
+    ALBUM_SHARE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ALBUM_SHARE_ALREADY_EXISTS", "이미 초대된 사용자입니다."),
+    ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE", "자기 자신의 역할은 수정할 수 없습니다."),
+    ALBUM_SHARE_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_OWNER_CANNOT_LEAVE", "소유자는 앨범을 탈퇴할 수 없습니다."),
+    ALBUM_SHARE_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_ALREADY_ACCEPTED", "이미 수락된 초대입니다."),
+
+
     // 캘린더 타임라인 코드
     INVALID_QUERY(HttpStatus.BAD_REQUEST, "INVALID_QUERY", "year와 month 파라미터는 필수입니다.");
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ spring:
       hibernate.format_sql: true
 
 app:
-  public-base-url: http://10.0.2.2:8080
+  public-base-url: http://localhost:8080
 
   jwt:
     # 최소 32바이트 이상. 예시는 Base64 32바이트(24 raw bytes)보다 더 긴 랜덤 문자열 권장.
@@ -31,7 +31,7 @@ app:
 
 
   s3:
-    bucket: nemo-s3-test
+    bucket: nemo-s3-prod
     region: ap-northeast-2
     endpoint: ""                    # AWS니까 endpoint 없음
     accessKey: ${AWS_ACCESS_KEY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: prod
+    active: dev
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 개요
앨범 썸네일 설정과 공유 앨범 관련 권한/즐겨찾기 동작을 API 명세에 맞게 정리하고,
공유받은 사용자의 사용성을 개선하기 위한 수정 PR입니다.

## 변경 사항

### 1. 앨범 썸네일 생성/지정 로직 정리
- 앨범 생성 시:
  - photoIdList가 있으면 해당 사진들 중에서 자동으로 대표 썸네일 선택
  - coverPhotoId가 전달되면 해당 사진을 대표 썸네일로 우선 적용
- 앨범 수정(PUT /api/albums/{albumId}) 시:
  - coverPhotoId가 들어오면 해당 앨범에 포함된 사진인지 검증 후 대표 썸네일 변경
- POST /api/albums/{albumId}/thumbnail:
  - JSON(photoId), multipart(file) 모두 optional
  - photoId만 있을 때: 해당 사진을 썸네일로 지정
  - file만 있을 때: 업로드된 이미지를 썸네일로 지정
  - 둘 다 없을 때: 앨범 내 최신 사진 기준으로 자동 썸네일 지정

### 2. 공유 멤버 목록에서 PENDING 필터링
- 공유 요청을 보냈지만 상대방이 아직 수락하지 않은 사용자는
  공유 멤버 목록에 표시되지 않도록 수정
- 공유 멤버 조회 시 ACCEPTED 상태만 반환되도록 로직 조정
- 필요 시 status 필드를 응답에 포함해 프론트에서 상태 표시가 가능하도록 구조 정리

### 3. 공유받은 사용자의 사진 즐겨찾기 허용
- 기존: 소유자 기반/토큰 검증 로직으로 인해 공유받은 사용자가 즐겨찾기 시도 시 401 발생
- 변경:
  - 공유받은 사용자(Viewer/Editor/Co-owner)가 해당 앨범/사진에 접근 가능한 경우 즐겨찾기 허용
  - 즐겨찾기 권한 체크를 공유 권한(canAccess…) 기반으로 변경

### 4. 공유받은 사용자의 상세 정보 조회
- 공유받은 사용자가 앨범/사진 상세 화면에서 정보가 비어 보이던 문제 수정
- 앨범 공유 상태(Status = ACCEPTED)와 Role(Viewer/Editor/Co-owner)에 따라
  상세 정보를 정상적으로 반환하도록 권한 검증 로직 보완

## 기대 효과
- 공유 요청 수락 이전/이후 상태가 화면에 명확하게 반영됩니다.
- 공유받은 사용자도 즐겨찾기 및 상세 조회를 정상적으로 사용할 수 있습니다.
- 썸네일 자동/수동 설정 동작이 API 명세 및 프론트 요구사항과 일치합니다.
