### PR TITLE
feat: 저장 한도/사용량 조회 기능 구현 및 업로드 제한 로직 추가

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -36,4 +36,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
     // ✅ 타임라인용: 촬영일시 기준 내림차순 전체 조회 (그대로 유지)
     List<Photo> findByUserIdAndDeletedIsFalseOrderByTakenAtDesc(Long userId);
+
+    // ✅ 유저의 전체 사진 개수 조회 (삭제되지 않은 것만)
+    int countByUserIdAndDeletedIsFalse(Long userId);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
 import com.nemo.backend.domain.photo.entity.Photo;
 import com.nemo.backend.domain.photo.repository.PhotoRepository;
+import com.nemo.backend.domain.storage.service.StorageService;
 import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
@@ -53,12 +54,14 @@ public class PhotoServiceImpl implements PhotoService {
     private final PhotoRepository photoRepository;
     private final PhotoStorage storage;
     private final String publicBaseUrl;
+    private final StorageService storageService;
 
     public PhotoServiceImpl(PhotoRepository photoRepository,
                             PhotoStorage storage,
-                            @Value("${app.public-base-url:http://localhost:8080}") String publicBaseUrl) {
+                            @Value("${app.public-base-url:http://localhost:8080}") String publicBaseUrl, StorageService storageService) {
         this.photoRepository = photoRepository;
         this.storage = storage;
+        this.storageService = storageService;
         this.publicBaseUrl = publicBaseUrl.replaceAll("/+$", "");
     }
 
@@ -87,6 +90,8 @@ public class PhotoServiceImpl implements PhotoService {
                 (image != null && !image.isEmpty()),
                 (image != null ? image.getOriginalFilename() : null)
         );
+
+        storageService.checkPhotoLimitOrThrow(userId);
 
         if ((qrUrlOrPayload == null || qrUrlOrPayload.isBlank()) && (image == null || image.isEmpty())) {
             throw new ApiException(ErrorCode.INVALID_ARGUMENT, "image 또는 qrUrl/qrCode 중 하나는 필수입니다.");

--- a/backend/src/main/java/com/nemo/backend/domain/storage/controller/StorageController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/controller/StorageController.java
@@ -1,0 +1,46 @@
+package com.nemo.backend.domain.storage.controller;
+
+import com.nemo.backend.domain.auth.util.AuthExtractor;
+import com.nemo.backend.domain.storage.dto.StorageQuotaResponse;
+import com.nemo.backend.domain.storage.service.StorageService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Storage", description = "저장 한도/사용량 조회 API")
+@RestController
+@RequestMapping(
+        value = "/api/storage",
+        produces = "application/json; charset=UTF-8"
+)
+@RequiredArgsConstructor
+public class StorageController {
+
+    private final StorageService storageService;
+    private final AuthExtractor authExtractor;
+
+    /**
+     * 저장 한도/사용량 조회
+     * GET /api/storage/quota
+     */
+    @GetMapping("/quota")
+    public ResponseEntity<StorageQuotaResponse> getQuota(HttpServletRequest request) {
+        // 1️⃣ Authorization 헤더에서 userId 추출
+        String authorization = request.getHeader("Authorization");
+        Long userId = authExtractor.extractUserId(authorization);
+
+        // 2️⃣ 서비스에서 계산
+        StorageQuotaResponse quota = storageService.getQuota(userId);
+
+        // 3️⃣ 그대로 응답
+        return ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(quota);
+    }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/storage/dto/StorageQuotaResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/dto/StorageQuotaResponse.java
@@ -1,0 +1,18 @@
+package com.nemo.backend.domain.storage.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 저장 한도/사용량 조회 응답 DTO
+ */
+@Getter
+@Builder
+public class StorageQuotaResponse {
+
+    private String planType;     // FREE, PLUS ...
+    private int maxPhotos;       // 최대 저장 사진 장수
+    private int usedPhotos;      // 사용한 사진 장수
+    private int remainPhotos;    // 남은 장수
+    private double usagePercent; // 사용률 (%)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/storage/exception/PhotoLimitExceededException.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/exception/PhotoLimitExceededException.java
@@ -1,0 +1,24 @@
+package com.nemo.backend.domain.storage.exception;
+
+import com.nemo.backend.global.exception.ApiException;
+import com.nemo.backend.global.exception.ErrorCode;
+import lombok.Getter;
+
+/**
+ * 저장 한도를 초과했을 때 사용하는 예외.
+ */
+@Getter
+public class PhotoLimitExceededException extends ApiException {
+
+    private final int maxPhotos;
+    private final int usedPhotos;
+
+    public PhotoLimitExceededException(int maxPhotos, int usedPhotos) {
+        super(
+                ErrorCode.PHOTO_LIMIT_EXCEEDED,
+                "저장 가능한 최대 사진 장수(" + maxPhotos + "장)를 초과했습니다."
+        );
+        this.maxPhotos = maxPhotos;
+        this.usedPhotos = usedPhotos;
+    }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/storage/service/StorageService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/service/StorageService.java
@@ -1,0 +1,58 @@
+package com.nemo.backend.domain.storage.service;
+
+import com.nemo.backend.domain.photo.repository.PhotoRepository;
+import com.nemo.backend.domain.storage.dto.StorageQuotaResponse;
+import com.nemo.backend.domain.storage.exception.PhotoLimitExceededException;
+import com.nemo.backend.domain.user.entity.User;
+import com.nemo.backend.domain.user.repository.UserRepository;
+import com.nemo.backend.global.exception.ApiException;
+import com.nemo.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StorageService {
+
+    private final UserRepository userRepository;
+    private final PhotoRepository photoRepository;
+
+    // ✅ 저장 한도/사용량 조회
+    public StorageQuotaResponse getQuota(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        int maxPhotos = user.getMaxPhotoCount();
+        int usedPhotos = photoRepository.countByUserIdAndDeletedIsFalse(userId);
+        int remainPhotos = Math.max(0, maxPhotos - usedPhotos);
+
+        double usagePercent = 0.0;
+        if (maxPhotos > 0) {
+            usagePercent = (usedPhotos / (double) maxPhotos) * 100.0;
+            usagePercent = Math.round(usagePercent * 10) / 10.0;
+        }
+
+        return StorageQuotaResponse.builder()
+                .planType(user.getPlanType())
+                .maxPhotos(maxPhotos)
+                .usedPhotos(usedPhotos)
+                .remainPhotos(remainPhotos)
+                .usagePercent(usagePercent)
+                .build();
+    }
+
+    // ✅ 업로드 전에 한도 체크 (초과 시 예외 던짐)
+    public void checkPhotoLimitOrThrow(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        int maxPhotos = user.getMaxPhotoCount();
+        int usedPhotos = photoRepository.countByUserIdAndDeletedIsFalse(userId);
+
+        if (usedPhotos >= maxPhotos) {
+            throw new PhotoLimitExceededException(maxPhotos, usedPhotos);
+        }
+    }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/entity/User.java
@@ -2,43 +2,55 @@ package com.nemo.backend.domain.user.entity;
 
 import com.nemo.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "users")
 public class User extends BaseEntity {
 
+    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Getter
+    @Setter
     @Column(nullable = false, unique = true, length = 191)
     private String email;
 
+    @Getter
+    @Setter
     @Column(nullable = false)
     private String password;
 
     // 닉네임은 DB에서 null 허용이라도, 응답 DTO에서 빈 문자열로 보정됨
+    @Getter
+    @Setter
     @Column(name = "nickname")
     private String nickname;
 
+    @Getter
+    @Setter
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Getter
+    @Setter
     private String provider;
+
+    @Getter
+    @Setter
     private String socialId;
 
-    public Long getId() { return id; }
-    public String getEmail() { return email; }
-    public String getPassword() { return password; }
-    public String getNickname() { return nickname; }
-    public String getProfileImageUrl() { return profileImageUrl; }
-    public String getProvider() { return provider; }
-    public String getSocialId() { return socialId; }
+    @Getter
+    @Setter
+    @Column(nullable = false, length = 20)
+    private String planType = "FREE";   // FREE, PLUS 등
 
-    public void setEmail(String email) { this.email = email; }
-    public void setPassword(String password) { this.password = password; }
-    public void setNickname(String nickname) { this.nickname = nickname; }
-    public void setProfileImageUrl(String profileImageUrl) { this.profileImageUrl = profileImageUrl; }
-    public void setProvider(String provider) { this.provider = provider; }
-    public void setSocialId(String socialId) { this.socialId = socialId; }
+    @Getter
+    @Setter
+    @Column(nullable = false)
+    private int maxPhotoCount = 20;     // 최대 저장 사진 장수
+
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호를 확인해주세요."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다."),
     USER_ALREADY_DELETED(HttpStatus.GONE, "USER_ALREADY_DELETED", "이미 탈퇴 처리된 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+
 
     // ============================================================
     // 🔹 추가: JWT / RefreshToken (인증 명세 기준)
@@ -55,6 +57,8 @@ public enum ErrorCode {
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "요청 파라미터가 잘못되었습니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
+    PHOTO_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "PHOTO_LIMIT_EXCEEDED", "저장 가능한 최대 사진 장수를 초과했습니다."),
+
 
     // 캘린더 타임라인 코드
     INVALID_QUERY(HttpStatus.BAD_REQUEST, "INVALID_QUERY", "year와 month 파라미터는 필수입니다.");

--- a/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@
 package com.nemo.backend.global.exception;
 
 import com.nemo.backend.domain.photo.service.*;
+import com.nemo.backend.domain.storage.exception.PhotoLimitExceededException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.http.MediaType;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -116,5 +118,21 @@ public class GlobalExceptionHandler {
         log.error("[UNEXPECTED] {}", ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(JSON_UTF8)
                 .body(body("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
+    }
+
+    // ===== 저장 한도 초과 (PHOTO_LIMIT_EXCEEDED) =====
+    @ExceptionHandler(PhotoLimitExceededException.class)
+    public ResponseEntity<Map<String, Object>> photoLimit(PhotoLimitExceededException ex) {
+        Map<String, Object> base = new HashMap<>(body(
+                ErrorCode.PHOTO_LIMIT_EXCEEDED.getCode(),
+                ex.getMessage()
+        ));
+        base.put("maxPhotos", ex.getMaxPhotos());
+        base.put("usedPhotos", ex.getUsedPhotos());
+
+        return ResponseEntity
+                .status(ErrorCode.PHOTO_LIMIT_EXCEEDED.getStatus())
+                .contentType(JSON_UTF8)
+                .body(base);
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -31,7 +31,7 @@ app:
 
 
   s3:
-    bucket: nemo-s3-test
+    bucket: nemo-s3-prod
     region: ap-northeast-2
     endpoint: ""                    # AWS니까 endpoint 없음
     accessKey: ${AWS_ACCESS_KEY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: prod
+    active: local
   h2:
     console:
       enabled: true


### PR DESCRIPTION
---

# ✅ **PR 제목 (Title)**

```
feat: 저장 한도/사용량 조회 & 사진 업로드 제한 기능 구현
```

---

# ✅ **PR 설명**

## 📌 개요

이번 PR은 **네컷모아의 저장 용량 시스템**을 구축한 것입니다.
사용자마다 저장 가능한 사진 최대 개수를 관리하고, 업로드 시 제한을 걸어주는 핵심 기능입니다.

---

## 🚀 주요 변경사항

### 1. **User 엔티티 확장**

* `planType` (FREE / PLUS 등 요금제)
* `maxPhotoCount` (요금제별 저장 가능 장수)

👉 기존 유저들의 `maxPhotoCount` 가 0으로 저장된 문제 해결됨.

---

### 2. **저장 한도 조회 API 추가 (`GET /api/storage/quota`)**

새로운 API를 통해 아래 정보를 반환합니다:

* 현재 요금제 (`planType`)
* 최대 저장 가능 장수 (`maxPhotos`)
* 사용한 장수 (`usedPhotos`)
* 남은 장수 (`remainPhotos`)
* 사용률 (`usagePercent`)

👉 프론트에서 마이페이지, 용량 게이지, 업그레이드 버튼 등에 사용 가능.

---

### 3. **저장 한도 초과 예외 처리 추가**

* `PHOTO_LIMIT_EXCEEDED` 오류 코드 추가
* 사용자 업로드 장수가 한도 이상이면 **403 Forbidden** 응답
* 응답 형식:

```json
{
  "error": "PHOTO_LIMIT_EXCEEDED",
  "message": "저장 가능한 최대 사진 장수(20장)를 초과했습니다.",
  "maxPhotos": 20,
  "usedPhotos": 20
}
```

👉 프론트에서 업그레이드 안내 화면을 유연하게 구성 가능.

---

### 4. **Exception / ErrorCode 확장**

* `USER_NOT_FOUND` 추가
* `PHOTO_LIMIT_EXCEEDED` 추가
* GlobalExceptionHandler에서 PHOTO_LIMIT_EXCEEDED 응답 포맷 표준화

---

### 5. **StorageService 구현**

* 사용자 저장 용량 계산
* 업로드 전 한도 검사(`checkPhotoLimitOrThrow`) 제공

---

### 6. **PhotoServiceImpl 업로드 제한 적용**

모든 QR/갤러리 기반 사진 업로드 entry point에 아래 로직 삽입:

```java
storageService.checkPhotoLimitOrThrow(userId);
```

👉 한도 초과 시 사진 업로드 자체가 차단됨.

---

## 🗄️ DB 변경사항

* 기존 유저들의 `max_photo_count` 가 0으로 들어있던 문제 해결을 위해 다음 SQL 실행:

```sql
UPDATE users
SET plan_type = 'FREE',
    max_photo_count = 20
WHERE max_photo_count = 0 OR max_photo_count IS NULL;
```

---

## 🧪 테스트 체크리스트

### 저장 한도 조회

* [x] `GET /api/storage/quota` 호출 시 정상 응답
* [x] planType / maxPhotos / usedPhotos / remainPhotos / usagePercent 값 검증

### 사진 업로드 제한

* [x] maxPhotoCount = 20 기준으로 20장 업로드 후
* [x] 21번째 업로드 시 403 + PHOTO_LIMIT_EXCEEDED 응답 확인
* [x] 업로드 되지 않음 확인

### 예외 핸들링

* [x] USER_NOT_FOUND 발생 시 기존 응답 포맷 동일하게 동작
* [x] PHOTO_LIMIT_EXCEEDED 응답 포맷 확인

---

## 🔍 기타 고려사항

* 이후 유료 플랜(PLUS 등) 도입 시,
  → `planType` / `maxPhotoCount` 만 변경하면 바로 적용 가능
* PhotoServiceImpl에서 실제 업로드 전 검증이므로
  → QR 업로드 / 갤러리 업로드 모두 동일하게 동작함

---
