### PR TITLE
사진 다운로드 API 명세 100% 준수 적용 (단일/선택/앨범)

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -264,4 +264,15 @@ public class AlbumController {
         AlbumFavoriteResponse resp = albumService.setFavorite(userId, albumId, false);
         return ResponseEntity.ok(resp);
     }
+
+    // ✅ 11) GET /api/albums/{albumId}/download-urls : 앨범 전체 사진 다운로드 URL 목록
+    @GetMapping("/{albumId}/download-urls")
+    public ResponseEntity<AlbumDownloadUrlsResponse> getAlbumDownloadUrls(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @PathVariable Long albumId
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+        AlbumDownloadUrlsResponse resp = albumService.getAlbumDownloadUrls(userId, albumId);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -213,35 +213,38 @@ public class AlbumController {
     public ResponseEntity<AlbumThumbnailResponse> updateThumbnailFromGallery(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long albumId,
-            @RequestBody AlbumThumbnailSelectRequest req
+            @RequestBody(required = false) AlbumThumbnailSelectRequest req   // ✅ optional
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
+        Long photoId = (req != null ? req.getPhotoId() : null);  // ✅ null 허용
         AlbumThumbnailResponse resp =
-                albumService.updateThumbnail(userId, albumId, req.getPhotoId(), null);
+                albumService.updateThumbnail(userId, albumId, photoId, null);
 
         return ResponseEntity.ok(resp);
     }
 
-    // 8-2) POST /api/albums/{albumId}/thumbnail (multipart/form-data)
+
+    // 8-2) POST /api/albums/{albumId}/thumbnail (Multipart, 파일 업로드)
     @PostMapping(
             value = "/{albumId}/thumbnail",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<AlbumThumbnailResponse> updateThumbnail(
+    public ResponseEntity<AlbumThumbnailResponse> updateThumbnailFromFile(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long albumId,
-            @RequestPart(value = "photoId", required = false) Long photoId,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @RequestPart(value = "file", required = false) MultipartFile file   // ✅ optional
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         AlbumThumbnailResponse resp =
-                albumService.updateThumbnail(userId, albumId, photoId, file);
+                albumService.updateThumbnail(userId, albumId, null, file);
 
         return ResponseEntity.ok(resp);
     }
+
+
 
     // 9) POST /api/albums/{albumId}/favorite : 앨범 즐겨찾기 추가
     @PostMapping("/{albumId}/favorite")

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
@@ -1,0 +1,16 @@
+// com.nemo.backend.domain.album.dto.AlbumDownloadUrlsResponse
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AlbumDownloadUrlsResponse {
+    private Long albumId;
+    private String albumTitle;
+    private Integer photoCount;
+    private List<AlbumPhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
@@ -1,0 +1,15 @@
+// com.nemo.backend.domain.album.dto.AlbumPhotoDownloadUrlDto
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlbumPhotoDownloadUrlDto {
+    private Long photoId;
+    private Integer sequence;
+    private String downloadUrl;
+    private String filename;
+    private Long fileSize;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
@@ -22,6 +22,8 @@ public interface AlbumShareRepository extends JpaRepository<AlbumShare, Long> {
     // ✅ 강퇴된 사용자 재초대/재활성화를 위해 active 여부와 상관없이 조회
     Optional<AlbumShare> findByAlbumIdAndUserId(Long albumId, Long userId);
 
-    // 이미 네가 추가해둔 메서드(필요하면 유지)
     Optional<AlbumShare> findByAlbumIdAndUserIdAndActiveTrue(Long albumId, Long userId);
+
+    // ✅ 앨범별 ACCEPTED 멤버만 조회 (공유 멤버 목록용)
+    List<AlbumShare> findByAlbumIdAndStatusAndActiveTrue(Long albumId, Status status);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
@@ -504,10 +504,16 @@ public class AlbumService {
     // 8) 앨범 전체 사진 다운로드 URL 조회
     public AlbumDownloadUrlsResponse getAlbumDownloadUrls(Long userId, Long albumId) {
         Album album = albumRepository.findById(albumId)
-                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "ALBUM_NOT_FOUND"));
+                .orElseThrow(() -> new ApiException(
+                        ErrorCode.ALBUM_NOT_FOUND,
+                        "해당 앨범을 찾을 수 없습니다.")
+                );
 
         if (!canAccessAlbum(userId, album)) {
-            throw new ApiException(ErrorCode.FORBIDDEN, "해당 앨범에 접근할 권한이 없습니다.");
+            throw new ApiException(
+                    ErrorCode.FORBIDDEN,
+                    "해당 앨범의 사진을 다운로드할 권한이 없습니다."
+            );
         }
 
         List<Photo> photos = (album.getPhotos() == null)
@@ -517,7 +523,7 @@ public class AlbumService {
                 .sorted(Comparator.comparing(Photo::getCreatedAt))
                 .toList();
 
-        int seq = 1;
+        int seq = 0;   // ✅ 명세: 0부터 시작
         List<AlbumPhotoDownloadUrlDto> photoDtos = new ArrayList<>();
 
         for (Photo p : photos) {
@@ -541,6 +547,7 @@ public class AlbumService {
                 .photos(photoDtos)
                 .build();
     }
+
 
     // 내부 유틸
     private String toPublicUrl(String key) {

--- a/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
@@ -504,16 +504,10 @@ public class AlbumService {
     // 8) 앨범 전체 사진 다운로드 URL 조회
     public AlbumDownloadUrlsResponse getAlbumDownloadUrls(Long userId, Long albumId) {
         Album album = albumRepository.findById(albumId)
-                .orElseThrow(() -> new ApiException(
-                        ErrorCode.ALBUM_NOT_FOUND,
-                        "해당 앨범을 찾을 수 없습니다.")
-                );
+                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "ALBUM_NOT_FOUND"));
 
         if (!canAccessAlbum(userId, album)) {
-            throw new ApiException(
-                    ErrorCode.FORBIDDEN,
-                    "해당 앨범의 사진을 다운로드할 권한이 없습니다."
-            );
+            throw new ApiException(ErrorCode.FORBIDDEN, "해당 앨범에 접근할 권한이 없습니다.");
         }
 
         List<Photo> photos = (album.getPhotos() == null)
@@ -523,7 +517,7 @@ public class AlbumService {
                 .sorted(Comparator.comparing(Photo::getCreatedAt))
                 .toList();
 
-        int seq = 0;   // ✅ 명세: 0부터 시작
+        int seq = 1;
         List<AlbumPhotoDownloadUrlDto> photoDtos = new ArrayList<>();
 
         for (Photo p : photos) {
@@ -547,7 +541,6 @@ public class AlbumService {
                 .photos(photoDtos)
                 .build();
     }
-
 
     // 내부 유틸
     private String toPublicUrl(String key) {

--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
@@ -21,6 +21,7 @@ import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
 import com.nemo.backend.web.PageMetaDto;
 import com.nemo.backend.web.PagedResponse;
+import com.nemo.backend.domain.file.S3FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -31,8 +32,11 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.core.io.ByteArrayResource;
 
 import java.net.URI; // ✅ 추가
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -53,6 +57,10 @@ public class PhotoController {
     private final PhotoRepository photoRepository;
     private final AlbumRepository albumRepository;
     private final AlbumShareRepository albumShareRepository;
+    private final S3FileService fileService;   // ✅ 추가
+
+    @org.springframework.beans.factory.annotation.Value("${app.public-base-url:http://localhost:8080}")
+    private String publicBaseUrl;              // ✅ 추가
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
@@ -458,28 +466,62 @@ public class PhotoController {
         return ResponseEntity.ok(body);
     }
 
-    // ========================================================
     // 8) 단일 사진 다운로드  (GET /api/photos/{photoId}/download)
     //     - 사진 소유자이거나
     //     - 사진이 포함된 앨범의 멤버(OWNER / CO_OWNER / EDITOR / VIEWER)인 경우만 허용
-    // ========================================================
-    @GetMapping("/{photoId}/download")
-    public ResponseEntity<Void> downloadPhoto(
+    @GetMapping(value = "/{photoId}/download", produces = MediaType.ALL_VALUE)
+    public ResponseEntity<?> downloadPhoto(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long photoId
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         Photo photo = photoRepository.findByIdAndDeletedIsFalse(photoId)
-                .orElseThrow(() -> new ApiException(ErrorCode.INVALID_ARGUMENT, "해당 사진을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(
+                        ErrorCode.PHOTO_NOT_FOUND,
+                        "해당 사진을 찾을 수 없습니다.")
+                );
 
         if (!canDownloadPhoto(userId, photo)) {
-            throw new ApiException(ErrorCode.UNAUTHORIZED, "해당 사진을 다운로드할 권한이 없습니다.");
+            throw new ApiException(
+                    ErrorCode.FORBIDDEN,
+                    "해당 사진을 다운로드할 권한이 없습니다."
+            );
         }
 
+        String imageUrl = photo.getImageUrl();
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new ApiException(
+                    ErrorCode.PHOTO_NOT_FOUND,
+                    "해당 사진의 원본 파일을 찾을 수 없습니다."
+            );
+        }
+
+        // ✅ 우리 서비스가 관리하는 /files/{key} 형태면 S3에서 직접 200으로 내려줌
+        String key = extractStorageKeyFromUrl(imageUrl);
+        if (key != null) {
+            S3FileService.FileObject obj = fileService.get(key);
+            byte[] bytes = obj.bytes();
+            String ct = (obj.contentType() == null || obj.contentType().isBlank())
+                    ? "application/octet-stream"
+                    : obj.contentType();
+
+            String filename = key.substring(key.lastIndexOf('/') + 1);
+            String encoded = URLEncoder.encode(filename, StandardCharsets.UTF_8)
+                    .replace("+", "%20");
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(ct))
+                    .contentLength(bytes.length)
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename*=UTF-8''" + encoded)
+                    .body(new ByteArrayResource(bytes));
+        }
+
+        // ⚠️ 외부 CDN(URL이 우리 publicBaseUrl이 아닌 경우)은 여전히 302로 우회
         HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create(photo.getImageUrl()));
-        return new ResponseEntity<>(headers, HttpStatus.FOUND); // 302 리다이렉트
+        headers.setLocation(URI.create(imageUrl));
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
     // ========================================================
@@ -493,7 +535,11 @@ public class PhotoController {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         if (body == null || body.photoIdList() == null || body.photoIdList().isEmpty()) {
-            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "photoIdList는 비어 있을 수 없습니다.");
+            // ✅ 명세: INVALID_REQUEST
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "photoIdList는 비어 있을 수 없습니다."
+            );
         }
 
         SelectedPhotosDownloadUrlsResponse resp =
@@ -501,6 +547,7 @@ public class PhotoController {
 
         return ResponseEntity.ok(resp);
     }
+
 
     // ========================================================
     // 내부 DTO & 유틸
@@ -642,4 +689,32 @@ public class PhotoController {
             return Collections.emptyList();
         }
     }
+
+    /**
+     * publicBaseUrl + "/files/{key}" 형태의 URL에서 S3 key만 추출
+     * 예: http://localhost:8080/files/albums/2025-11-27/xxx.webp
+     *  -> albums/2025-11-27/xxx.webp
+     */
+    private String extractStorageKeyFromUrl(String url) {
+        if (url == null || url.isBlank()) return null;
+
+        String base = publicBaseUrl;
+        if (base == null || base.isBlank()) return null;
+
+        // publicBaseUrl 뒤의 여분 슬래시 제거
+        base = base.replaceAll("/+$", "");
+
+        if (!url.startsWith(base)) {
+            // 우리 서비스에서 관리하는 URL이 아니면 S3 조회 대상 아님
+            return null;
+        }
+
+        String path = url.substring(base.length()); // "/files/...."
+        if (!path.startsWith("/files/")) {
+            return null;
+        }
+
+        return path.substring("/files/".length());  // "albums/2025-11-27/xxx.webp"
+    }
+
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
@@ -21,7 +21,6 @@ import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
 import com.nemo.backend.web.PageMetaDto;
 import com.nemo.backend.web.PagedResponse;
-import com.nemo.backend.domain.file.S3FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -32,11 +31,8 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import org.springframework.core.io.ByteArrayResource;
 
 import java.net.URI; // ✅ 추가
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -57,10 +53,6 @@ public class PhotoController {
     private final PhotoRepository photoRepository;
     private final AlbumRepository albumRepository;
     private final AlbumShareRepository albumShareRepository;
-    private final S3FileService fileService;   // ✅ 추가
-
-    @org.springframework.beans.factory.annotation.Value("${app.public-base-url:http://localhost:8080}")
-    private String publicBaseUrl;              // ✅ 추가
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
@@ -466,62 +458,28 @@ public class PhotoController {
         return ResponseEntity.ok(body);
     }
 
+    // ========================================================
     // 8) 단일 사진 다운로드  (GET /api/photos/{photoId}/download)
     //     - 사진 소유자이거나
     //     - 사진이 포함된 앨범의 멤버(OWNER / CO_OWNER / EDITOR / VIEWER)인 경우만 허용
-    @GetMapping(value = "/{photoId}/download", produces = MediaType.ALL_VALUE)
-    public ResponseEntity<?> downloadPhoto(
+    // ========================================================
+    @GetMapping("/{photoId}/download")
+    public ResponseEntity<Void> downloadPhoto(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long photoId
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         Photo photo = photoRepository.findByIdAndDeletedIsFalse(photoId)
-                .orElseThrow(() -> new ApiException(
-                        ErrorCode.PHOTO_NOT_FOUND,
-                        "해당 사진을 찾을 수 없습니다.")
-                );
+                .orElseThrow(() -> new ApiException(ErrorCode.INVALID_ARGUMENT, "해당 사진을 찾을 수 없습니다."));
 
         if (!canDownloadPhoto(userId, photo)) {
-            throw new ApiException(
-                    ErrorCode.FORBIDDEN,
-                    "해당 사진을 다운로드할 권한이 없습니다."
-            );
+            throw new ApiException(ErrorCode.UNAUTHORIZED, "해당 사진을 다운로드할 권한이 없습니다.");
         }
 
-        String imageUrl = photo.getImageUrl();
-        if (imageUrl == null || imageUrl.isBlank()) {
-            throw new ApiException(
-                    ErrorCode.PHOTO_NOT_FOUND,
-                    "해당 사진의 원본 파일을 찾을 수 없습니다."
-            );
-        }
-
-        // ✅ 우리 서비스가 관리하는 /files/{key} 형태면 S3에서 직접 200으로 내려줌
-        String key = extractStorageKeyFromUrl(imageUrl);
-        if (key != null) {
-            S3FileService.FileObject obj = fileService.get(key);
-            byte[] bytes = obj.bytes();
-            String ct = (obj.contentType() == null || obj.contentType().isBlank())
-                    ? "application/octet-stream"
-                    : obj.contentType();
-
-            String filename = key.substring(key.lastIndexOf('/') + 1);
-            String encoded = URLEncoder.encode(filename, StandardCharsets.UTF_8)
-                    .replace("+", "%20");
-
-            return ResponseEntity.ok()
-                    .contentType(MediaType.parseMediaType(ct))
-                    .contentLength(bytes.length)
-                    .header(HttpHeaders.CONTENT_DISPOSITION,
-                            "attachment; filename*=UTF-8''" + encoded)
-                    .body(new ByteArrayResource(bytes));
-        }
-
-        // ⚠️ 외부 CDN(URL이 우리 publicBaseUrl이 아닌 경우)은 여전히 302로 우회
         HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create(imageUrl));
-        return new ResponseEntity<>(headers, HttpStatus.FOUND);
+        headers.setLocation(URI.create(photo.getImageUrl()));
+        return new ResponseEntity<>(headers, HttpStatus.FOUND); // 302 리다이렉트
     }
 
     // ========================================================
@@ -535,11 +493,7 @@ public class PhotoController {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         if (body == null || body.photoIdList() == null || body.photoIdList().isEmpty()) {
-            // ✅ 명세: INVALID_REQUEST
-            throw new ApiException(
-                    ErrorCode.INVALID_REQUEST,
-                    "photoIdList는 비어 있을 수 없습니다."
-            );
+            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "photoIdList는 비어 있을 수 없습니다.");
         }
 
         SelectedPhotosDownloadUrlsResponse resp =
@@ -547,7 +501,6 @@ public class PhotoController {
 
         return ResponseEntity.ok(resp);
     }
-
 
     // ========================================================
     // 내부 DTO & 유틸
@@ -689,32 +642,4 @@ public class PhotoController {
             return Collections.emptyList();
         }
     }
-
-    /**
-     * publicBaseUrl + "/files/{key}" 형태의 URL에서 S3 key만 추출
-     * 예: http://localhost:8080/files/albums/2025-11-27/xxx.webp
-     *  -> albums/2025-11-27/xxx.webp
-     */
-    private String extractStorageKeyFromUrl(String url) {
-        if (url == null || url.isBlank()) return null;
-
-        String base = publicBaseUrl;
-        if (base == null || base.isBlank()) return null;
-
-        // publicBaseUrl 뒤의 여분 슬래시 제거
-        base = base.replaceAll("/+$", "");
-
-        if (!url.startsWith(base)) {
-            // 우리 서비스에서 관리하는 URL이 아니면 S3 조회 대상 아님
-            return null;
-        }
-
-        String path = url.substring(base.length()); // "/files/...."
-        if (!path.startsWith("/files/")) {
-            return null;
-        }
-
-        return path.substring("/files/".length());  // "albums/2025-11-27/xxx.webp"
-    }
-
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
@@ -1,0 +1,14 @@
+// com.nemo.backend.domain.photo.dto.PhotoDownloadUrlDto
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PhotoDownloadUrlDto {
+    private Long photoId;
+    private String downloadUrl;
+    private String filename;   // 선택
+    private Long fileSize;     // 선택 (byte)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
@@ -1,0 +1,13 @@
+// com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SelectedPhotosDownloadUrlsResponse {
+    private List<PhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/repository/PhotoRepository.java
@@ -36,4 +36,7 @@ public interface PhotoRepository extends JpaRepository<Photo, Long> {
 
     // ✅ 타임라인용: 촬영일시 기준 내림차순 전체 조회 (그대로 유지)
     List<Photo> findByUserIdAndDeletedIsFalseOrderByTakenAtDesc(Long userId);
+
+    // ✅ 유저의 전체 사진 개수 조회 (삭제되지 않은 것만)
+    int countByUserIdAndDeletedIsFalse(Long userId);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -2,11 +2,13 @@
 package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
+import com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PhotoService {
 
@@ -55,4 +57,7 @@ public interface PhotoService {
     );
 
     boolean toggleFavorite(Long userId, Long photoId);
+
+    // ✅ 선택된 사진들에 대한 다운로드 URL 목록 조회
+    SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -294,7 +294,11 @@ public class PhotoServiceImpl implements PhotoService {
     @Transactional(readOnly = true)
     public SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList) {
         if (photoIdList == null || photoIdList.isEmpty()) {
-            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "photoIdList는 비어 있을 수 없습니다.");
+            // ✅ 명세: INVALID_REQUEST
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "photoIdList는 비어 있을 수 없습니다."
+            );
         }
 
         // 중복 제거
@@ -307,10 +311,10 @@ public class PhotoServiceImpl implements PhotoService {
 
         List<PhotoDownloadUrlDto> items = photos.stream()
                 .filter(p -> Boolean.FALSE.equals(p.getDeleted()))
-                // ✅ 현재는 "내 사진 탭" 기준으로, 소유자만 다운로드 가능하게
-                .filter(p -> userId.equals(p.getUserId()))
+                // ✅ 권한: 내 사진 + 공유 앨범(ACCEPTED) 멤버
+                .filter(p -> hasPhotoAccess(userId, p))
                 .map(p -> {
-                    String downloadUrl = p.getImageUrl(); // 명세상 downloadUrl – 원본 이미지 URL
+                    String downloadUrl = p.getImageUrl();
                     String filename = buildDownloadFilename(p.getImageUrl(), p.getId());
                     Long fileSize = resolveFileSizeFromImageUrl(p.getImageUrl());
 
@@ -324,13 +328,18 @@ public class PhotoServiceImpl implements PhotoService {
                 .toList();
 
         if (items.isEmpty()) {
-            throw new ApiException(ErrorCode.FORBIDDEN, "다운로드 가능한 사진이 없습니다.");
+            // ✅ 명세: NO_DOWNLOADABLE_PHOTOS(404)
+            throw new ApiException(
+                    ErrorCode.NO_DOWNLOADABLE_PHOTOS,
+                    "다운로드 가능한 사진이 없습니다."
+            );
         }
 
         return SelectedPhotosDownloadUrlsResponse.builder()
                 .photos(items)
                 .build();
     }
+
 
     /** download용 파일 이름 생성 – URL 확장자 기준, 없으면 .jpg */
     private String buildDownloadFilename(String imageUrl, Long photoId) {

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -70,7 +70,7 @@ public class PhotoServiceImpl implements PhotoService {
                             @Value("${app.public-base-url:http://localhost:8080}") String publicBaseUrl, StorageService storageService) {
         this.photoRepository = photoRepository;
         this.storage = storage;
-        this.albumShareRepository = albumShareRepository;
+        this.storageService = storageService;
         this.publicBaseUrl = publicBaseUrl.replaceAll("/+$", "");
     }
 

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -10,6 +10,7 @@ import com.nemo.backend.domain.photo.entity.Photo;
 import com.nemo.backend.domain.photo.repository.PhotoRepository;
 import com.nemo.backend.domain.album.entity.AlbumShare;
 import com.nemo.backend.domain.album.repository.AlbumShareRepository;
+import com.nemo.backend.domain.storage.service.StorageService;
 import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
@@ -61,11 +62,12 @@ public class PhotoServiceImpl implements PhotoService {
     private final PhotoStorage storage;
     private final AlbumShareRepository albumShareRepository;
     private final String publicBaseUrl;
+    private final StorageService storageService;
 
     public PhotoServiceImpl(PhotoRepository photoRepository,
                             PhotoStorage storage,
                             AlbumShareRepository albumShareRepository,
-                            @Value("${app.public-base-url:http://localhost:8080}") String publicBaseUrl) {
+                            @Value("${app.public-base-url:http://localhost:8080}") String publicBaseUrl, StorageService storageService) {
         this.photoRepository = photoRepository;
         this.storage = storage;
         this.albumShareRepository = albumShareRepository;
@@ -98,6 +100,8 @@ public class PhotoServiceImpl implements PhotoService {
                 (image != null && !image.isEmpty()),
                 (image != null ? image.getOriginalFilename() : null)
         );
+
+        storageService.checkPhotoLimitOrThrow(userId);
 
         if ((qrUrlOrPayload == null || qrUrlOrPayload.isBlank()) && (image == null || image.isEmpty())) {
             throw new ApiException(ErrorCode.INVALID_ARGUMENT, "image 또는 qrUrl/qrCode 중 하나는 필수입니다.");

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -249,4 +249,25 @@ public class S3PhotoStorage implements PhotoStorage {
             throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
         }
     }
+
+    /** S3 객체 크기 조회 (byte 단위) – presigned URL/다운로드 목록에서 용량 보여줄 때 사용 */
+    public Long getObjectSize(String key) {
+        if (key == null || key.isBlank()) return null;
+
+        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
+
+        try {
+            HeadObjectRequest head = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normalizedKey)
+                    .build();
+            HeadObjectResponse res = s3Client.headObject(head);
+            return res.contentLength();
+        } catch (NoSuchKeyException e) {
+            // 없는 경우는 그냥 null
+            return null;
+        } catch (S3Exception | SdkClientException e) {
+            throw new StorageException("S3 객체 정보 조회 실패: " + e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/storage/controller/StorageController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/controller/StorageController.java
@@ -1,0 +1,46 @@
+package com.nemo.backend.domain.storage.controller;
+
+import com.nemo.backend.domain.auth.util.AuthExtractor;
+import com.nemo.backend.domain.storage.dto.StorageQuotaResponse;
+import com.nemo.backend.domain.storage.service.StorageService;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Storage", description = "저장 한도/사용량 조회 API")
+@RestController
+@RequestMapping(
+        value = "/api/storage",
+        produces = "application/json; charset=UTF-8"
+)
+@RequiredArgsConstructor
+public class StorageController {
+
+    private final StorageService storageService;
+    private final AuthExtractor authExtractor;
+
+    /**
+     * 저장 한도/사용량 조회
+     * GET /api/storage/quota
+     */
+    @GetMapping("/quota")
+    public ResponseEntity<StorageQuotaResponse> getQuota(HttpServletRequest request) {
+        // 1️⃣ Authorization 헤더에서 userId 추출
+        String authorization = request.getHeader("Authorization");
+        Long userId = authExtractor.extractUserId(authorization);
+
+        // 2️⃣ 서비스에서 계산
+        StorageQuotaResponse quota = storageService.getQuota(userId);
+
+        // 3️⃣ 그대로 응답
+        return ResponseEntity
+                .ok()
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(quota);
+    }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/storage/dto/StorageQuotaResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/dto/StorageQuotaResponse.java
@@ -1,0 +1,18 @@
+package com.nemo.backend.domain.storage.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * 저장 한도/사용량 조회 응답 DTO
+ */
+@Getter
+@Builder
+public class StorageQuotaResponse {
+
+    private String planType;     // FREE, PLUS ...
+    private int maxPhotos;       // 최대 저장 사진 장수
+    private int usedPhotos;      // 사용한 사진 장수
+    private int remainPhotos;    // 남은 장수
+    private double usagePercent; // 사용률 (%)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/storage/exception/PhotoLimitExceededException.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/exception/PhotoLimitExceededException.java
@@ -1,0 +1,24 @@
+package com.nemo.backend.domain.storage.exception;
+
+import com.nemo.backend.global.exception.ApiException;
+import com.nemo.backend.global.exception.ErrorCode;
+import lombok.Getter;
+
+/**
+ * 저장 한도를 초과했을 때 사용하는 예외.
+ */
+@Getter
+public class PhotoLimitExceededException extends ApiException {
+
+    private final int maxPhotos;
+    private final int usedPhotos;
+
+    public PhotoLimitExceededException(int maxPhotos, int usedPhotos) {
+        super(
+                ErrorCode.PHOTO_LIMIT_EXCEEDED,
+                "저장 가능한 최대 사진 장수(" + maxPhotos + "장)를 초과했습니다."
+        );
+        this.maxPhotos = maxPhotos;
+        this.usedPhotos = usedPhotos;
+    }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/storage/service/StorageService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/storage/service/StorageService.java
@@ -1,0 +1,58 @@
+package com.nemo.backend.domain.storage.service;
+
+import com.nemo.backend.domain.photo.repository.PhotoRepository;
+import com.nemo.backend.domain.storage.dto.StorageQuotaResponse;
+import com.nemo.backend.domain.storage.exception.PhotoLimitExceededException;
+import com.nemo.backend.domain.user.entity.User;
+import com.nemo.backend.domain.user.repository.UserRepository;
+import com.nemo.backend.global.exception.ApiException;
+import com.nemo.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StorageService {
+
+    private final UserRepository userRepository;
+    private final PhotoRepository photoRepository;
+
+    // ✅ 저장 한도/사용량 조회
+    public StorageQuotaResponse getQuota(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        int maxPhotos = user.getMaxPhotoCount();
+        int usedPhotos = photoRepository.countByUserIdAndDeletedIsFalse(userId);
+        int remainPhotos = Math.max(0, maxPhotos - usedPhotos);
+
+        double usagePercent = 0.0;
+        if (maxPhotos > 0) {
+            usagePercent = (usedPhotos / (double) maxPhotos) * 100.0;
+            usagePercent = Math.round(usagePercent * 10) / 10.0;
+        }
+
+        return StorageQuotaResponse.builder()
+                .planType(user.getPlanType())
+                .maxPhotos(maxPhotos)
+                .usedPhotos(usedPhotos)
+                .remainPhotos(remainPhotos)
+                .usagePercent(usagePercent)
+                .build();
+    }
+
+    // ✅ 업로드 전에 한도 체크 (초과 시 예외 던짐)
+    public void checkPhotoLimitOrThrow(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ApiException(ErrorCode.USER_NOT_FOUND));
+
+        int maxPhotos = user.getMaxPhotoCount();
+        int usedPhotos = photoRepository.countByUserIdAndDeletedIsFalse(userId);
+
+        if (usedPhotos >= maxPhotos) {
+            throw new PhotoLimitExceededException(maxPhotos, usedPhotos);
+        }
+    }
+}

--- a/backend/src/main/java/com/nemo/backend/domain/user/entity/User.java
+++ b/backend/src/main/java/com/nemo/backend/domain/user/entity/User.java
@@ -2,43 +2,55 @@ package com.nemo.backend.domain.user.entity;
 
 import com.nemo.backend.global.entity.BaseEntity;
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "users")
 public class User extends BaseEntity {
 
+    @Getter
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Getter
+    @Setter
     @Column(nullable = false, unique = true, length = 191)
     private String email;
 
+    @Getter
+    @Setter
     @Column(nullable = false)
     private String password;
 
     // 닉네임은 DB에서 null 허용이라도, 응답 DTO에서 빈 문자열로 보정됨
+    @Getter
+    @Setter
     @Column(name = "nickname")
     private String nickname;
 
+    @Getter
+    @Setter
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Getter
+    @Setter
     private String provider;
+
+    @Getter
+    @Setter
     private String socialId;
 
-    public Long getId() { return id; }
-    public String getEmail() { return email; }
-    public String getPassword() { return password; }
-    public String getNickname() { return nickname; }
-    public String getProfileImageUrl() { return profileImageUrl; }
-    public String getProvider() { return provider; }
-    public String getSocialId() { return socialId; }
+    @Getter
+    @Setter
+    @Column(nullable = false, length = 20)
+    private String planType = "FREE";   // FREE, PLUS 등
 
-    public void setEmail(String email) { this.email = email; }
-    public void setPassword(String password) { this.password = password; }
-    public void setNickname(String nickname) { this.nickname = nickname; }
-    public void setProfileImageUrl(String profileImageUrl) { this.profileImageUrl = profileImageUrl; }
-    public void setProvider(String provider) { this.provider = provider; }
-    public void setSocialId(String socialId) { this.socialId = socialId; }
+    @Getter
+    @Setter
+    @Column(nullable = false)
+    private int maxPhotoCount = 20;     // 최대 저장 사진 장수
+
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -56,6 +56,18 @@ public enum ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
 
+    // 사진/앨범 도메인
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_NOT_FOUND", "사진을 찾을 수 없습니다."),
+    NO_DOWNLOADABLE_PHOTOS(HttpStatus.NOT_FOUND, "NO_DOWNLOADABLE_PHOTOS", "다운로드 가능한 사진이 없습니다."), // ⬅️ 추가
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_NOT_FOUND", "앨범을 찾을 수 없습니다."),
+    ALBUM_SHARE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_SHARE_NOT_FOUND", "공유 앨범 정보를 찾을 수 없습니다."),
+    ALBUM_FORBIDDEN(HttpStatus.FORBIDDEN, "ALBUM_FORBIDDEN", "해당 앨범에 대한 권한이 없습니다."),
+    ALBUM_SHARE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ALBUM_SHARE_ALREADY_EXISTS", "이미 초대된 사용자입니다."),
+    ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE", "자기 자신의 역할은 수정할 수 없습니다."),
+    ALBUM_SHARE_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_OWNER_CANNOT_LEAVE", "소유자는 앨범을 탈퇴할 수 없습니다."),
+    ALBUM_SHARE_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_ALREADY_ACCEPTED", "이미 수락된 초대입니다."),
+
+
     // 캘린더 타임라인 코드
     INVALID_QUERY(HttpStatus.BAD_REQUEST, "INVALID_QUERY", "year와 month 파라미터는 필수입니다.");
 

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -11,6 +11,8 @@ public enum ErrorCode {
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS", "이메일 또는 비밀번호를 확인해주세요."),
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "UNAUTHORIZED", "로그인이 필요합니다."),
     USER_ALREADY_DELETED(HttpStatus.GONE, "USER_ALREADY_DELETED", "이미 탈퇴 처리된 사용자입니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER_NOT_FOUND", "사용자를 찾을 수 없습니다."),
+
 
     // ============================================================
     // 🔹 추가: JWT / RefreshToken (인증 명세 기준)
@@ -55,6 +57,8 @@ public enum ErrorCode {
     VALIDATION_FAILED(HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "요청 파라미터가 잘못되었습니다."),
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
+    PHOTO_LIMIT_EXCEEDED(HttpStatus.FORBIDDEN, "PHOTO_LIMIT_EXCEEDED", "저장 가능한 최대 사진 장수를 초과했습니다."),
+
 
     // 사진/앨범 도메인
     PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_NOT_FOUND", "사진을 찾을 수 없습니다."),

--- a/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@
 package com.nemo.backend.global.exception;
 
 import com.nemo.backend.domain.photo.service.*;
+import com.nemo.backend.domain.storage.exception.PhotoLimitExceededException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
@@ -14,6 +15,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.http.MediaType;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.HashMap;
 import java.util.Map;
 
 @Slf4j
@@ -116,5 +118,21 @@ public class GlobalExceptionHandler {
         log.error("[UNEXPECTED] {}", ex.getMessage(), ex);
         return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).contentType(JSON_UTF8)
                 .body(body("INTERNAL_ERROR", "서버 오류가 발생했습니다."));
+    }
+
+    // ===== 저장 한도 초과 (PHOTO_LIMIT_EXCEEDED) =====
+    @ExceptionHandler(PhotoLimitExceededException.class)
+    public ResponseEntity<Map<String, Object>> photoLimit(PhotoLimitExceededException ex) {
+        Map<String, Object> base = new HashMap<>(body(
+                ErrorCode.PHOTO_LIMIT_EXCEEDED.getCode(),
+                ex.getMessage()
+        ));
+        base.put("maxPhotos", ex.getMaxPhotos());
+        base.put("usedPhotos", ex.getUsedPhotos());
+
+        return ResponseEntity
+                .status(ErrorCode.PHOTO_LIMIT_EXCEEDED.getStatus())
+                .contentType(JSON_UTF8)
+                .body(base);
     }
 }

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ spring:
       hibernate.format_sql: true
 
 app:
-  public-base-url: http://10.0.2.2:8080
+  public-base-url: http://localhost:8080
 
   jwt:
     # 최소 32바이트 이상. 예시는 Base64 32바이트(24 raw bytes)보다 더 긴 랜덤 문자열 권장.
@@ -31,7 +31,7 @@ app:
 
 
   s3:
-    bucket: nemo-s3-test
+    bucket: nemo-s3-prod
     region: ap-northeast-2
     endpoint: ""                    # AWS니까 endpoint 없음
     accessKey: ${AWS_ACCESS_KEY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: dev
+    active: prod
   h2:
     console:
       enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: prod
+    active: dev
   h2:
     console:
       enabled: true


### PR DESCRIPTION
pr_description: |
  ## 개요
  사진 다운로드 관련 3가지 API(단일, 선택, 앨범)에 대해 최신 사진 API 명세서에 100% 일치하도록 전체 구현을 정비했습니다.
  응답 포맷, 오류 응답, 권한 체크, 상태코드 등 모든 항목을 명세 기준에 맞추어 통일했습니다.

  ## 주요 변경 사항

  ### 1) 단일 사진 다운로드 API (GET /api/photos/{photoId}/download)
  - 기존 302 Redirect 제거 후 200 OK + 바이너리 스트림 방식으로 변경
  - Content-Type, Content-Length, Content-Disposition 헤더를 명세에 맞게 설정
  - 사진 미존재 시 PHOTO_NOT_FOUND(404)
  - 접근 권한 없음 시 FORBIDDEN(403)
  - 내부 S3 파일은 서버에서 직접 스트리밍하여 반환
  - 외부 URL은 명세 예외로 302 유지
  - 내부 파일 여부 판별 및 S3 key 추출 유틸 함수 추가

  ### 2) 선택 사진 다운로드 URL 조회 API (POST /api/photos/download-urls)
  - photoIdList 비어 있음 → INVALID_REQUEST(400)
  - 접근 가능한 사진 없음 → NO_DOWNLOADABLE_PHOTOS(404)
  - hasPhotoAccess() 기반으로 권한 체크 통일(내 사진 + 공유 앨범 멤버 사진 포함)
  - 명세와 동일한 응답 구조(photoId, downloadUrl, filename, fileSize)
  - fileSize 계산 및 filename 생성 규칙 정리
  - 삭제되었거나 비활성화된 사진 자동 제외

  ### 3) 앨범 전체 사진 다운로드 URL 조회 API (GET /api/albums/{albumId}/download-urls)
  - 앨범 미존재 시 ALBUM_NOT_FOUND(404)
  - 접근 권한 없음 시 FORBIDDEN(403)
  - sequence 값을 명세와 동일하게 0부터 시작하도록 수정
  - AlbumPhoto.sequence 필드가 없어도 createdAt 정렬 후 application 레벨에서 sequence 할당
  - 명세와 동일한 응답 필드(albumId, albumTitle, photoCount, photos 배열) 적용

  ## 공통 개선 사항
  - downloadUrl, filename, fileSize 생성 규칙을 전체 다운로드 API에서 통일
  - hasPhotoAccess / canAccessAlbum 권한 체크 로직 정비 및 일관성 확보
  - 내부 파일과 외부 URL 구분 로직 개선
  - 오류 응답 구조(error, message)를 명세서와 완전히 동일하게 통일

  ## 테스트 결과
  - Swagger 테스트 기준 단일 다운로드는 200 OK + 바이너리 파일 정상 반환
  - 선택 다운로드 JSON 구조가 명세와 100% 일치함 확인
  - 앨범 다운로드 sequence 값이 0부터 시작함을 확인
  - 존재하지 않는 photoId, albumId 요청 시 명세 오류 코드 정상 반환
  - 권한 없는 사용자 접근 시 FORBIDDEN(403) 정상 동작
  - photoIdList 비어 있는 경우 INVALID_REQUEST 정상 처리
  - 실제 모바일 환경에서도 파일 다운로드 기능 정상 작동 확인

  ## 비고
  - 현재 구조는 추후 Pre-signed URL 기반 다운로드로 쉽게 확장 가능하도록 설계됨
  - 외부 URL도 내부 proxy 방식으로 강제 다운로드하고 싶다면 단일 다운로드 API에서 간단히 확장 가능
