### PR TITLE
앨범 공유 권한 매트릭스 적용 및 AlbumShareService 전면 리팩터링

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -264,4 +264,15 @@ public class AlbumController {
         AlbumFavoriteResponse resp = albumService.setFavorite(userId, albumId, false);
         return ResponseEntity.ok(resp);
     }
+
+    // ✅ 11) GET /api/albums/{albumId}/download-urls : 앨범 전체 사진 다운로드 URL 목록
+    @GetMapping("/{albumId}/download-urls")
+    public ResponseEntity<AlbumDownloadUrlsResponse> getAlbumDownloadUrls(
+            @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
+            @PathVariable Long albumId
+    ) {
+        Long userId = authExtractor.extractUserId(authorizationHeader);
+        AlbumDownloadUrlsResponse resp = albumService.getAlbumDownloadUrls(userId, albumId);
+        return ResponseEntity.ok(resp);
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/controller/AlbumController.java
@@ -213,35 +213,38 @@ public class AlbumController {
     public ResponseEntity<AlbumThumbnailResponse> updateThumbnailFromGallery(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long albumId,
-            @RequestBody AlbumThumbnailSelectRequest req
+            @RequestBody(required = false) AlbumThumbnailSelectRequest req   // ✅ optional
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
+        Long photoId = (req != null ? req.getPhotoId() : null);  // ✅ null 허용
         AlbumThumbnailResponse resp =
-                albumService.updateThumbnail(userId, albumId, req.getPhotoId(), null);
+                albumService.updateThumbnail(userId, albumId, photoId, null);
 
         return ResponseEntity.ok(resp);
     }
 
-    // 8-2) POST /api/albums/{albumId}/thumbnail (multipart/form-data)
+
+    // 8-2) POST /api/albums/{albumId}/thumbnail (Multipart, 파일 업로드)
     @PostMapping(
             value = "/{albumId}/thumbnail",
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
             produces = MediaType.APPLICATION_JSON_VALUE
     )
-    public ResponseEntity<AlbumThumbnailResponse> updateThumbnail(
+    public ResponseEntity<AlbumThumbnailResponse> updateThumbnailFromFile(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long albumId,
-            @RequestPart(value = "photoId", required = false) Long photoId,
-            @RequestPart(value = "file", required = false) MultipartFile file
+            @RequestPart(value = "file", required = false) MultipartFile file   // ✅ optional
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         AlbumThumbnailResponse resp =
-                albumService.updateThumbnail(userId, albumId, photoId, file);
+                albumService.updateThumbnail(userId, albumId, null, file);
 
         return ResponseEntity.ok(resp);
     }
+
+
 
     // 9) POST /api/albums/{albumId}/favorite : 앨범 즐겨찾기 추가
     @PostMapping("/{albumId}/favorite")

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumDownloadUrlsResponse.java
@@ -1,0 +1,16 @@
+// com.nemo.backend.domain.album.dto.AlbumDownloadUrlsResponse
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AlbumDownloadUrlsResponse {
+    private Long albumId;
+    private String albumTitle;
+    private Integer photoCount;
+    private List<AlbumPhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/dto/AlbumPhotoDownloadUrlDto.java
@@ -1,0 +1,15 @@
+// com.nemo.backend.domain.album.dto.AlbumPhotoDownloadUrlDto
+package com.nemo.backend.domain.album.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AlbumPhotoDownloadUrlDto {
+    private Long photoId;
+    private Integer sequence;
+    private String downloadUrl;
+    private String filename;
+    private Long fileSize;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/repository/AlbumShareRepository.java
@@ -22,6 +22,8 @@ public interface AlbumShareRepository extends JpaRepository<AlbumShare, Long> {
     // ✅ 강퇴된 사용자 재초대/재활성화를 위해 active 여부와 상관없이 조회
     Optional<AlbumShare> findByAlbumIdAndUserId(Long albumId, Long userId);
 
-    // 이미 네가 추가해둔 메서드(필요하면 유지)
     Optional<AlbumShare> findByAlbumIdAndUserIdAndActiveTrue(Long albumId, Long userId);
+
+    // ✅ 앨범별 ACCEPTED 멤버만 조회 (공유 멤버 목록용)
+    List<AlbumShare> findByAlbumIdAndStatusAndActiveTrue(Long albumId, Status status);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
@@ -504,10 +504,16 @@ public class AlbumService {
     // 8) 앨범 전체 사진 다운로드 URL 조회
     public AlbumDownloadUrlsResponse getAlbumDownloadUrls(Long userId, Long albumId) {
         Album album = albumRepository.findById(albumId)
-                .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "ALBUM_NOT_FOUND"));
+                .orElseThrow(() -> new ApiException(
+                        ErrorCode.ALBUM_NOT_FOUND,
+                        "해당 앨범을 찾을 수 없습니다.")
+                );
 
         if (!canAccessAlbum(userId, album)) {
-            throw new ApiException(ErrorCode.FORBIDDEN, "해당 앨범에 접근할 권한이 없습니다.");
+            throw new ApiException(
+                    ErrorCode.FORBIDDEN,
+                    "해당 앨범의 사진을 다운로드할 권한이 없습니다."
+            );
         }
 
         List<Photo> photos = (album.getPhotos() == null)
@@ -517,7 +523,7 @@ public class AlbumService {
                 .sorted(Comparator.comparing(Photo::getCreatedAt))
                 .toList();
 
-        int seq = 1;
+        int seq = 0;   // ✅ 명세: 0부터 시작
         List<AlbumPhotoDownloadUrlDto> photoDtos = new ArrayList<>();
 
         for (Photo p : photos) {
@@ -541,6 +547,7 @@ public class AlbumService {
                 .photos(photoDtos)
                 .build();
     }
+
 
     // 내부 유틸
     private String toPublicUrl(String key) {

--- a/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumShareService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumShareService.java
@@ -278,6 +278,11 @@ public class AlbumShareService {
         EffectiveRole actorRole = resolveEffectiveRole(album, meId);
         EffectiveRole targetRole = resolveEffectiveRoleForShare(album, share);
 
+        // 🔒 CO_OWNER 는 다른 사용자를 CO_OWNER 로 승격시킬 수 없다
+        if (actorRole == EffectiveRole.CO_OWNER && newRole == Role.CO_OWNER) {
+            throw new ApiException(ErrorCode.FORBIDDEN, "CO_OWNER 는 다른 사용자를 CO_OWNER 로 변경할 수 없습니다.");
+        }
+
         if (!canChangeMemberRole(actorRole, targetRole)) {
             throw new ApiException(ErrorCode.FORBIDDEN, "공유 멤버 권한을 변경할 수 없습니다.");
         }
@@ -285,6 +290,7 @@ public class AlbumShareService {
         share.setRole(newRole);
         return share;
     }
+
 
     /**
      * 공유 해제 / 강퇴

--- a/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumShareService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumShareService.java
@@ -30,12 +30,100 @@ public class AlbumShareService {
     private final FriendRepository friendRepository;
     private final UserRepository userRepository;
 
+    /**
+     * 앨범 내에서의 실질적인 역할
+     * - OWNER  : album.user (AlbumShare row 없음)
+     * - CO_OWNER / EDITOR / VIEWER : AlbumShare.Role 기반
+     */
+    private enum EffectiveRole {
+        OWNER,
+        CO_OWNER,
+        EDITOR,
+        VIEWER
+    }
+
+    /**
+     * 현재 사용자의 EffectiveRole 계산
+     * - 앨범 소유자이면 OWNER
+     * - 그렇지 않으면 ACCEPTED && active=true 인 AlbumShare 를 조회
+     *   없으면 FORBIDDEN
+     */
+    private EffectiveRole resolveEffectiveRole(Album album, Long userId) {
+        if (album.getUser() != null && album.getUser().getId().equals(userId)) {
+            return EffectiveRole.OWNER;
+        }
+
+        AlbumShare myShare = albumShareRepository
+                .findByAlbumIdAndUserIdAndStatusAndActiveTrue(album.getId(), userId, Status.ACCEPTED)
+                .orElseThrow(() -> new ApiException(ErrorCode.FORBIDDEN, "해당 앨범의 공유 멤버가 아닙니다."));
+
+        return switch (myShare.getRole()) {
+            case CO_OWNER -> EffectiveRole.CO_OWNER;
+            case EDITOR -> EffectiveRole.EDITOR;
+            case VIEWER -> EffectiveRole.VIEWER;
+        };
+    }
+
+    /**
+     * 특정 공유 레코드의 EffectiveRole 계산
+     * (원칙적으로 OWNER 는 AlbumShare 에 저장되지 않지만 방어적으로 한 번 더 체크)
+     */
+    private EffectiveRole resolveEffectiveRoleForShare(Album album, AlbumShare share) {
+        if (album.getUser() != null && album.getUser().getId().equals(share.getUser().getId())) {
+            return EffectiveRole.OWNER;
+        }
+        return switch (share.getRole()) {
+            case CO_OWNER -> EffectiveRole.CO_OWNER;
+            case EDITOR -> EffectiveRole.EDITOR;
+            case VIEWER -> EffectiveRole.VIEWER;
+        };
+    }
+
+    /**
+     * 권한 변경 가능 여부
+     * - OWNER  : CO_OWNER ~ VIEWER 모두 변경 가능
+     * - CO_OWNER : EDITOR ~ VIEWER 변경 가능
+     * - EDITOR / VIEWER : 변경 불가
+     */
+    private boolean canChangeMemberRole(EffectiveRole actor, EffectiveRole target) {
+        return switch (actor) {
+            case OWNER -> target == EffectiveRole.CO_OWNER
+                    || target == EffectiveRole.EDITOR
+                    || target == EffectiveRole.VIEWER;
+            case CO_OWNER -> target == EffectiveRole.EDITOR
+                    || target == EffectiveRole.VIEWER;
+            default -> false;
+        };
+    }
+
+    /**
+     * 강퇴 가능 여부
+     * - OWNER  : CO_OWNER ~ VIEWER 모두 강퇴 가능
+     * - CO_OWNER : EDITOR ~ VIEWER 강퇴 가능
+     * - EDITOR / VIEWER : 강퇴 불가
+     */
+    private boolean canKickMember(EffectiveRole actor, EffectiveRole target) {
+        return switch (actor) {
+            case OWNER -> target == EffectiveRole.CO_OWNER
+                    || target == EffectiveRole.EDITOR
+                    || target == EffectiveRole.VIEWER;
+            case CO_OWNER -> target == EffectiveRole.EDITOR
+                    || target == EffectiveRole.VIEWER;
+            default -> false;
+        };
+    }
+
     @Transactional(readOnly = true)
     public Album getAlbum(Long albumId) {
         return albumRepository.findById(albumId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "ALBUM_NOT_FOUND"));
     }
 
+    /**
+     * "관리 권한"이 필요한 작업용 (공유 요청 보내기, 공유 링크 생성 등)
+     * - OWNER
+     * - CO_OWNER
+     */
     private Album getAlbumWithManagePermission(Long albumId, Long meId) {
         Album album = getAlbum(albumId);
 
@@ -131,13 +219,21 @@ public class AlbumShareService {
                 .build();
     }
 
+    /**
+     * 공유 멤버 목록 조회
+     * - OWNER
+     * - 공유 멤버(ACCEPTED && active=true) → role 이 OWNER / CO_OWNER / EDITOR / VIEWER 여도 모두 조회 가능
+     */
     @Transactional(readOnly = true)
     public List<AlbumShareResponse.SharedUser> getShareTargets(Long albumId, Long meId) {
-        Album album = getAlbumWithManagePermission(albumId, meId);
+        Album album = getAlbum(albumId);
+
+        // 🔐 멤버 조회 권한 체크 (예외 발생 시 403)
+        resolveEffectiveRole(album, meId);
 
         List<AlbumShareResponse.SharedUser> result = new ArrayList<>();
 
-        // 1) 소유자 (명세상 OWNER 는 album.user 기반) :contentReference[oaicite:1]{index=1}
+        // 1) 소유자
         User owner = album.getUser();
         result.add(AlbumShareResponse.SharedUser.builder()
                 .userId(owner.getId())
@@ -146,7 +242,7 @@ public class AlbumShareService {
                 .build()
         );
 
-        // 2) ACCEPTED 상태인 공유 멤버만 포함
+        // 2) ACCEPTED 상태인 공유 멤버
         albumShareRepository.findByAlbumIdAndStatusAndActiveTrue(albumId, Status.ACCEPTED)
                 .forEach(share -> result.add(
                         AlbumShareResponse.SharedUser.builder()
@@ -159,9 +255,14 @@ public class AlbumShareService {
         return result;
     }
 
-
+    /**
+     * 공유 멤버 권한 변경
+     * - OWNER  : CO_OWNER ~ VIEWER 모두 변경 가능
+     * - CO_OWNER : EDITOR ~ VIEWER 권한 변경 가능
+     * - EDITOR / VIEWER : 변경 불가
+     */
     public AlbumShare updateShareRoleByUserId(Long albumId, Long targetUserId, Long meId, Role newRole) {
-        Album album = getAlbumWithManagePermission(albumId, meId);
+        Album album = getAlbum(albumId);
 
         AlbumShare share = albumShareRepository
                 .findByAlbumIdAndUserIdAndActiveTrue(albumId, targetUserId)
@@ -174,10 +275,24 @@ public class AlbumShareService {
             throw new ApiException(ErrorCode.INVALID_REQUEST, "활성화된 공유가 아닙니다.");
         }
 
+        EffectiveRole actorRole = resolveEffectiveRole(album, meId);
+        EffectiveRole targetRole = resolveEffectiveRoleForShare(album, share);
+
+        if (!canChangeMemberRole(actorRole, targetRole)) {
+            throw new ApiException(ErrorCode.FORBIDDEN, "공유 멤버 권한을 변경할 수 없습니다.");
+        }
+
         share.setRole(newRole);
         return share;
     }
 
+    /**
+     * 공유 해제 / 강퇴
+     * - 본인(target == meId) : 누구나 언제든지 나가기 가능
+     * - OWNER  : CO_OWNER ~ VIEWER 강퇴 가능
+     * - CO_OWNER : EDITOR ~ VIEWER 강퇴 가능
+     * - EDITOR / VIEWER : 강퇴 불가
+     */
     public Long unshare(Long albumId, Long targetUserId, Long meId) {
         Album album = getAlbum(albumId);
 
@@ -185,23 +300,25 @@ public class AlbumShareService {
                 .findByAlbumIdAndUserIdAndActiveTrue(albumId, targetUserId)
                 .orElseThrow(() -> new ApiException(ErrorCode.NOT_FOUND, "SHARE_NOT_FOUND"));
 
-        if (targetUserId.equals(meId)) {
+        if (!Boolean.TRUE.equals(share.getActive())) {
+            throw new ApiException(ErrorCode.INVALID_REQUEST, "이미 비활성화된 공유입니다.");
+        }
+
+        boolean selfUnshare = targetUserId.equals(meId);
+
+        if (selfUnshare) {
+            // ✅ 본인은 언제든지 나갈 수 있음
             if (!share.getUser().getId().equals(meId)) {
                 throw new ApiException(ErrorCode.FORBIDDEN, "본인 공유가 아닙니다.");
             }
         } else {
-            if (!album.getUser().getId().equals(meId)) {
-                AlbumShare myShare = albumShareRepository
-                        .findByAlbumIdAndUserIdAndStatusAndActiveTrue(albumId, meId, Status.ACCEPTED)
-                        .orElseThrow(() -> new ApiException(ErrorCode.FORBIDDEN, "앨범 공유 관리 권한이 없습니다."));
-                if (myShare.getRole() != Role.CO_OWNER) {
-                    throw new ApiException(ErrorCode.FORBIDDEN, "앨범 공유 관리 권한이 없습니다.");
-                }
-            }
-        }
+            // ✅ 타인 강퇴
+            EffectiveRole actorRole = resolveEffectiveRole(album, meId);
+            EffectiveRole targetRole = resolveEffectiveRoleForShare(album, share);
 
-        if (!Boolean.TRUE.equals(share.getActive())) {
-            throw new ApiException(ErrorCode.INVALID_REQUEST, "이미 비활성화된 공유입니다.");
+            if (!canKickMember(actorRole, targetRole)) {
+                throw new ApiException(ErrorCode.FORBIDDEN, "해당 사용자를 앨범에서 제거할 권한이 없습니다.");
+            }
         }
 
         Long removedUserId = share.getUser().getId();

--- a/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/controller/PhotoController.java
@@ -21,6 +21,7 @@ import com.nemo.backend.global.exception.ApiException;
 import com.nemo.backend.global.exception.ErrorCode;
 import com.nemo.backend.web.PageMetaDto;
 import com.nemo.backend.web.PagedResponse;
+import com.nemo.backend.domain.file.S3FileService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -31,8 +32,11 @@ import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.*;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.core.io.ByteArrayResource;
 
 import java.net.URI; // ✅ 추가
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -53,6 +57,10 @@ public class PhotoController {
     private final PhotoRepository photoRepository;
     private final AlbumRepository albumRepository;
     private final AlbumShareRepository albumShareRepository;
+    private final S3FileService fileService;   // ✅ 추가
+
+    @org.springframework.beans.factory.annotation.Value("${app.public-base-url:http://localhost:8080}")
+    private String publicBaseUrl;              // ✅ 추가
 
     private static final ObjectMapper JSON = new ObjectMapper();
 
@@ -458,28 +466,62 @@ public class PhotoController {
         return ResponseEntity.ok(body);
     }
 
-    // ========================================================
     // 8) 단일 사진 다운로드  (GET /api/photos/{photoId}/download)
     //     - 사진 소유자이거나
     //     - 사진이 포함된 앨범의 멤버(OWNER / CO_OWNER / EDITOR / VIEWER)인 경우만 허용
-    // ========================================================
-    @GetMapping("/{photoId}/download")
-    public ResponseEntity<Void> downloadPhoto(
+    @GetMapping(value = "/{photoId}/download", produces = MediaType.ALL_VALUE)
+    public ResponseEntity<?> downloadPhoto(
             @RequestHeader(value = "Authorization", required = false) String authorizationHeader,
             @PathVariable Long photoId
     ) {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         Photo photo = photoRepository.findByIdAndDeletedIsFalse(photoId)
-                .orElseThrow(() -> new ApiException(ErrorCode.INVALID_ARGUMENT, "해당 사진을 찾을 수 없습니다."));
+                .orElseThrow(() -> new ApiException(
+                        ErrorCode.PHOTO_NOT_FOUND,
+                        "해당 사진을 찾을 수 없습니다.")
+                );
 
         if (!canDownloadPhoto(userId, photo)) {
-            throw new ApiException(ErrorCode.UNAUTHORIZED, "해당 사진을 다운로드할 권한이 없습니다.");
+            throw new ApiException(
+                    ErrorCode.FORBIDDEN,
+                    "해당 사진을 다운로드할 권한이 없습니다."
+            );
         }
 
+        String imageUrl = photo.getImageUrl();
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new ApiException(
+                    ErrorCode.PHOTO_NOT_FOUND,
+                    "해당 사진의 원본 파일을 찾을 수 없습니다."
+            );
+        }
+
+        // ✅ 우리 서비스가 관리하는 /files/{key} 형태면 S3에서 직접 200으로 내려줌
+        String key = extractStorageKeyFromUrl(imageUrl);
+        if (key != null) {
+            S3FileService.FileObject obj = fileService.get(key);
+            byte[] bytes = obj.bytes();
+            String ct = (obj.contentType() == null || obj.contentType().isBlank())
+                    ? "application/octet-stream"
+                    : obj.contentType();
+
+            String filename = key.substring(key.lastIndexOf('/') + 1);
+            String encoded = URLEncoder.encode(filename, StandardCharsets.UTF_8)
+                    .replace("+", "%20");
+
+            return ResponseEntity.ok()
+                    .contentType(MediaType.parseMediaType(ct))
+                    .contentLength(bytes.length)
+                    .header(HttpHeaders.CONTENT_DISPOSITION,
+                            "attachment; filename*=UTF-8''" + encoded)
+                    .body(new ByteArrayResource(bytes));
+        }
+
+        // ⚠️ 외부 CDN(URL이 우리 publicBaseUrl이 아닌 경우)은 여전히 302로 우회
         HttpHeaders headers = new HttpHeaders();
-        headers.setLocation(URI.create(photo.getImageUrl()));
-        return new ResponseEntity<>(headers, HttpStatus.FOUND); // 302 리다이렉트
+        headers.setLocation(URI.create(imageUrl));
+        return new ResponseEntity<>(headers, HttpStatus.FOUND);
     }
 
     // ========================================================
@@ -493,7 +535,11 @@ public class PhotoController {
         Long userId = authExtractor.extractUserId(authorizationHeader);
 
         if (body == null || body.photoIdList() == null || body.photoIdList().isEmpty()) {
-            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "photoIdList는 비어 있을 수 없습니다.");
+            // ✅ 명세: INVALID_REQUEST
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "photoIdList는 비어 있을 수 없습니다."
+            );
         }
 
         SelectedPhotosDownloadUrlsResponse resp =
@@ -501,6 +547,7 @@ public class PhotoController {
 
         return ResponseEntity.ok(resp);
     }
+
 
     // ========================================================
     // 내부 DTO & 유틸
@@ -642,4 +689,32 @@ public class PhotoController {
             return Collections.emptyList();
         }
     }
+
+    /**
+     * publicBaseUrl + "/files/{key}" 형태의 URL에서 S3 key만 추출
+     * 예: http://localhost:8080/files/albums/2025-11-27/xxx.webp
+     *  -> albums/2025-11-27/xxx.webp
+     */
+    private String extractStorageKeyFromUrl(String url) {
+        if (url == null || url.isBlank()) return null;
+
+        String base = publicBaseUrl;
+        if (base == null || base.isBlank()) return null;
+
+        // publicBaseUrl 뒤의 여분 슬래시 제거
+        base = base.replaceAll("/+$", "");
+
+        if (!url.startsWith(base)) {
+            // 우리 서비스에서 관리하는 URL이 아니면 S3 조회 대상 아님
+            return null;
+        }
+
+        String path = url.substring(base.length()); // "/files/...."
+        if (!path.startsWith("/files/")) {
+            return null;
+        }
+
+        return path.substring("/files/".length());  // "albums/2025-11-27/xxx.webp"
+    }
+
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/PhotoDownloadUrlDto.java
@@ -1,0 +1,14 @@
+// com.nemo.backend.domain.photo.dto.PhotoDownloadUrlDto
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class PhotoDownloadUrlDto {
+    private Long photoId;
+    private String downloadUrl;
+    private String filename;   // 선택
+    private Long fileSize;     // 선택 (byte)
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/dto/SelectedPhotosDownloadUrlsResponse.java
@@ -1,0 +1,13 @@
+// com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse
+package com.nemo.backend.domain.photo.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class SelectedPhotosDownloadUrlsResponse {
+    private List<PhotoDownloadUrlDto> photos;
+}

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoService.java
@@ -2,11 +2,13 @@
 package com.nemo.backend.domain.photo.service;
 
 import com.nemo.backend.domain.photo.dto.PhotoResponseDto;
+import com.nemo.backend.domain.photo.dto.SelectedPhotosDownloadUrlsResponse;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface PhotoService {
 
@@ -55,4 +57,7 @@ public interface PhotoService {
     );
 
     boolean toggleFavorite(Long userId, Long photoId);
+
+    // ✅ 선택된 사진들에 대한 다운로드 URL 목록 조회
+    SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList);
 }

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -1188,6 +1188,7 @@ public class PhotoServiceImpl implements PhotoService {
         if (s.contains("photoism")) return "포토이즘";
         if (s.contains("signature")) return "포토시그니쳐";
         if (s.contains("twin")) return "트윈포토";
+        if (s.contains("photogray") || s.contains("pgshort") || s.contains("pg-qr-resource")) return "포토그레이";
         return "기타";
     }
 

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/PhotoServiceImpl.java
@@ -294,7 +294,11 @@ public class PhotoServiceImpl implements PhotoService {
     @Transactional(readOnly = true)
     public SelectedPhotosDownloadUrlsResponse getDownloadUrls(Long userId, List<Long> photoIdList) {
         if (photoIdList == null || photoIdList.isEmpty()) {
-            throw new ApiException(ErrorCode.INVALID_ARGUMENT, "photoIdList는 비어 있을 수 없습니다.");
+            // ✅ 명세: INVALID_REQUEST
+            throw new ApiException(
+                    ErrorCode.INVALID_REQUEST,
+                    "photoIdList는 비어 있을 수 없습니다."
+            );
         }
 
         // 중복 제거
@@ -307,10 +311,10 @@ public class PhotoServiceImpl implements PhotoService {
 
         List<PhotoDownloadUrlDto> items = photos.stream()
                 .filter(p -> Boolean.FALSE.equals(p.getDeleted()))
-                // ✅ 현재는 "내 사진 탭" 기준으로, 소유자만 다운로드 가능하게
-                .filter(p -> userId.equals(p.getUserId()))
+                // ✅ 권한: 내 사진 + 공유 앨범(ACCEPTED) 멤버
+                .filter(p -> hasPhotoAccess(userId, p))
                 .map(p -> {
-                    String downloadUrl = p.getImageUrl(); // 명세상 downloadUrl – 원본 이미지 URL
+                    String downloadUrl = p.getImageUrl();
                     String filename = buildDownloadFilename(p.getImageUrl(), p.getId());
                     Long fileSize = resolveFileSizeFromImageUrl(p.getImageUrl());
 
@@ -324,13 +328,18 @@ public class PhotoServiceImpl implements PhotoService {
                 .toList();
 
         if (items.isEmpty()) {
-            throw new ApiException(ErrorCode.FORBIDDEN, "다운로드 가능한 사진이 없습니다.");
+            // ✅ 명세: NO_DOWNLOADABLE_PHOTOS(404)
+            throw new ApiException(
+                    ErrorCode.NO_DOWNLOADABLE_PHOTOS,
+                    "다운로드 가능한 사진이 없습니다."
+            );
         }
 
         return SelectedPhotosDownloadUrlsResponse.builder()
                 .photos(items)
                 .build();
     }
+
 
     /** download용 파일 이름 생성 – URL 확장자 기준, 없으면 .jpg */
     private String buildDownloadFilename(String imageUrl, Long photoId) {

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -249,4 +249,25 @@ public class S3PhotoStorage implements PhotoStorage {
             throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
         }
     }
+
+    /** S3 객체 크기 조회 (byte 단위) – presigned URL/다운로드 목록에서 용량 보여줄 때 사용 */
+    public Long getObjectSize(String key) {
+        if (key == null || key.isBlank()) return null;
+
+        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
+
+        try {
+            HeadObjectRequest head = HeadObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(normalizedKey)
+                    .build();
+            HeadObjectResponse res = s3Client.headObject(head);
+            return res.contentLength();
+        } catch (NoSuchKeyException e) {
+            // 없는 경우는 그냥 null
+            return null;
+        } catch (S3Exception | SdkClientException e) {
+            throw new StorageException("S3 객체 정보 조회 실패: " + e.getMessage(), e);
+        }
+    }
 }

--- a/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/nemo/backend/global/exception/ErrorCode.java
@@ -56,6 +56,18 @@ public enum ErrorCode {
     INVALID_ARGUMENT(HttpStatus.BAD_REQUEST, "INVALID_ARGUMENT", "잘못된 입력입니다."),
     UPSTREAM_FAILED(HttpStatus.BAD_GATEWAY,  "UPSTREAM_FAILED", "원격 자산 추출 실패했습니다."),
 
+    // 사진/앨범 도메인
+    PHOTO_NOT_FOUND(HttpStatus.NOT_FOUND, "PHOTO_NOT_FOUND", "사진을 찾을 수 없습니다."),
+    NO_DOWNLOADABLE_PHOTOS(HttpStatus.NOT_FOUND, "NO_DOWNLOADABLE_PHOTOS", "다운로드 가능한 사진이 없습니다."), // ⬅️ 추가
+    ALBUM_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_NOT_FOUND", "앨범을 찾을 수 없습니다."),
+    ALBUM_SHARE_NOT_FOUND(HttpStatus.NOT_FOUND, "ALBUM_SHARE_NOT_FOUND", "공유 앨범 정보를 찾을 수 없습니다."),
+    ALBUM_FORBIDDEN(HttpStatus.FORBIDDEN, "ALBUM_FORBIDDEN", "해당 앨범에 대한 권한이 없습니다."),
+    ALBUM_SHARE_ALREADY_EXISTS(HttpStatus.CONFLICT, "ALBUM_SHARE_ALREADY_EXISTS", "이미 초대된 사용자입니다."),
+    ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_CANNOT_MODIFY_SELF_ROLE", "자기 자신의 역할은 수정할 수 없습니다."),
+    ALBUM_SHARE_OWNER_CANNOT_LEAVE(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_OWNER_CANNOT_LEAVE", "소유자는 앨범을 탈퇴할 수 없습니다."),
+    ALBUM_SHARE_ALREADY_ACCEPTED(HttpStatus.BAD_REQUEST, "ALBUM_SHARE_ALREADY_ACCEPTED", "이미 수락된 초대입니다."),
+
+
     // 캘린더 타임라인 코드
     INVALID_QUERY(HttpStatus.BAD_REQUEST, "INVALID_QUERY", "year와 month 파라미터는 필수입니다.");
 

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ spring:
       hibernate.format_sql: true
 
 app:
-  public-base-url: http://10.0.2.2:8080
+  public-base-url: http://localhost:8080
 
   jwt:
     # 최소 32바이트 이상. 예시는 Base64 32바이트(24 raw bytes)보다 더 긴 랜덤 문자열 권장.
@@ -31,7 +31,7 @@ app:
 
 
   s3:
-    bucket: nemo-s3-test
+    bucket: nemo-s3-prod
     region: ap-northeast-2
     endpoint: ""                    # AWS니까 endpoint 없음
     accessKey: ${AWS_ACCESS_KEY}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
     # ✅ 개발 중엔 local (CloudType DB 외부 접속)
     # ✅ 테스트용 H2는 dev
     # ✅ 실제 배포는 prod
-    active: prod
+    active: dev
   h2:
     console:
       enabled: true


### PR DESCRIPTION
## 개요
기존 AlbumShareService의 권한 처리 방식이 명세와 불일치하여,
OWNER / CO_OWNER / EDITOR / VIEWER 역할 기반의 권한 매트릭스를
백엔드 로직 전체에 정확히 반영하도록 구조를 전면 수정했습니다.

## 주요 변경 사항

### 1) EffectiveRole 도입
- 앨범 소유자(OWNER)와 공유 멤버(CO_OWNER/EDITOR/VIEWER)를 통합적으로 처리하기 위해
  EffectiveRole enum(OWNER, CO_OWNER, EDITOR, VIEWER)을 새로 정의했습니다.
- AlbumShare row가 없는 OWNER도 동일한 권한 구조로 판별할 수 있게 개선했습니다.

### 2) 멤버 조회 권한 수정
- 기존: OWNER, CO_OWNER만 조회 가능
- 변경: 공유 멤버면 누구나 조회 가능 (OWNER, CO_OWNER, EDITOR, VIEWER 전부 허용)

### 3) 권한 변경 로직 반영
- OWNER: CO_OWNER ~ VIEWER 모두 변경 가능
- CO_OWNER: EDITOR ~ VIEWER 변경 가능
- EDITOR, VIEWER: 권한 변경 불가
- 변경 가능 여부를 검사하는 canChangeMemberRole() 추가

### 4) 강퇴(unshare) 규칙 반영
- 본인 나가기: 항상 허용
- OWNER: CO_OWNER ~ VIEWER 강퇴 가능
- CO_OWNER: EDITOR ~ VIEWER 강퇴 가능
- EDITOR, VIEWER: 강퇴 불가
- 강퇴 가능 여부를 검사하는 canKickMember() 추가

### 5) AlbumShareService 전체 구조 정리
- resolveEffectiveRole(), resolveEffectiveRoleForShare() 등 역할 계산 로직 통합
- 권한 체크 위치 명확화
- 기존 로직 흐름은 유지하되, 권한 매트릭스 기준으로 예외 처리 강화

## 기대 효과
- API 명세에서 요구한 공유 권한 체계를 완전하게 준수
- 프론트엔드에서 역할별 UI 제어가 명확해짐
- 공유 로직 전체의 예측 가능성과 안정성이 크게 향상됨

## 기타
- 기능 변경 없고 권한 로직만 강화됨
- DTO, Controller 시그니처 변경 없음
