### PR TITLE
fix: 사진 삭제 시 앨범 썸네일 자동 정리 및 S3 삭제 안정화

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/album/service/AlbumService.java
@@ -578,22 +578,46 @@ public class AlbumService {
 
     /** 앨범의 coverPhotoUrl 자동 설정 로직 */
     private void autoSetThumbnailIfMissing(Album album) {
-
-        // 살아있는 사진이 하나도 없으면 썸네일 제거
-        boolean hasAlivePhoto = album.getPhotos() != null &&
-                album.getPhotos().stream()
-                        .anyMatch(p -> Boolean.FALSE.equals(p.getDeleted()));
-
-        if (!hasAlivePhoto) {
+        // 사진이 아예 없으면 썸네일 제거
+        if (album.getPhotos() == null || album.getPhotos().isEmpty()) {
             album.setCoverPhotoUrl(null);
             return;
         }
 
-        // coverPhotoUrl 이 비어 있을 때만 자동으로 채움
-        if (album.getCoverPhotoUrl() == null || album.getCoverPhotoUrl().isBlank()) {
+        // 살아있는 사진만 필터링
+        List<Photo> alivePhotos = album.getPhotos().stream()
+                .filter(p -> Boolean.FALSE.equals(p.getDeleted()))
+                .toList();
+
+        // 살아있는 사진 없으면 썸네일 제거
+        if (alivePhotos.isEmpty()) {
+            album.setCoverPhotoUrl(null);
+            return;
+        }
+
+        String cover = album.getCoverPhotoUrl();
+        final String coverUrl = cover;   // ← lambda에서 사용할 final 변수
+
+        // 기존 커버가 살아있는 사진을 가리키는지 검증
+        if (coverUrl != null && !coverUrl.isBlank()) {
+            boolean stillValid = alivePhotos.stream().anyMatch(p -> {
+                String candidate = (p.getThumbnailUrl() != null && !p.getThumbnailUrl().isBlank())
+                        ? p.getThumbnailUrl()
+                        : p.getImageUrl();
+                return coverUrl.equals(candidate);
+            });
+
+            // 커버가 더 이상 유효하지 않으면 제거
+            if (!stillValid) {
+                cover = null;
+                album.setCoverPhotoUrl(null);
+            }
+        }
+
+        // cover가 비어 있으면 자동 선정
+        if (cover == null || cover.isBlank()) {
             album.setCoverPhotoUrl(pickAutoThumbnailUrl(album));
         }
-        // 이미 값이 있으면 (사용자 지정/업로드) 건드리지 않음
     }
 
     private String pickAutoThumbnailUrl(Album album) {

--- a/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
+++ b/backend/src/main/java/com/nemo/backend/domain/photo/service/S3PhotoStorage.java
@@ -615,25 +615,22 @@ public class S3PhotoStorage implements PhotoStorage {
 
     /** S3 객체 삭제 */
     @Override
-    public void delete(String key) {
-        if (key == null || key.isBlank()) return;
-
-        String normalizedKey = key.startsWith("/") ? key.substring(1) : key;
-
+    public void delete(String storedFilename) {
         try {
-            DeleteObjectRequest req = DeleteObjectRequest.builder()
+            DeleteObjectRequest request = DeleteObjectRequest.builder()
                     .bucket(bucket)
-                    .key(normalizedKey)
+                    .key(storedFilename)
                     .build();
 
-            s3Client.deleteObject(req);
+            s3Client.deleteObject(request);
 
-        } catch (NoSuchKeyException e) {
-            // 이미 안 존재하는 경우는 무시
-        } catch (S3Exception | SdkClientException e) {
-            throw new StorageException("S3 삭제 실패: " + e.getMessage(), e);
+            log.info("[S3] deleted file={}", storedFilename);
+
+        } catch (Exception e) {
+            throw new StorageException("Failed to delete S3 object", e);
         }
     }
+
 
     /** S3 객체 크기 조회 (byte 단위) – presigned URL/다운로드 목록에서 용량 보여줄 때 사용 */
     public Long getObjectSize(String key) {
@@ -655,4 +652,6 @@ public class S3PhotoStorage implements PhotoStorage {
             throw new StorageException("S3 객체 정보 조회 실패: " + e.getMessage(), e);
         }
     }
+
+
 }


### PR DESCRIPTION
🎯 개요

사진 삭제 시 해당 사진이 앨범 썸네일(coverPhotoUrl)로 사용되고 있는 경우,
앱 UI에 계속 썸네일이 남아 있는 문제가 발생하던 버그를 수정했습니다.

또한 PhotoService 삭제 로직에서 S3 삭제가 정상 동작하도록 점검하고 안정화했습니다.

🛠 주요 변경 사항
1. 사진 삭제 시 앨범 썸네일 자동 무효화

기존 로직에서는 coverPhotoUrl이 살아있는 사진인지 검증하지 않아,
삭제된 사진을 계속 커버로 사용하게 되는 문제가 있었음.

이번 수정으로:

삭제된 사진이 coverPhotoUrl을 가리키면 즉시 null 처리

살아있는 사진이 없다면 커버 완전 제거

coverPhotoUrl이 유효하지 않으면 자동으로 다른 사진으로 재설정

이제 썸네일이 항상 “실제 존재하는 사진”을 기반으로 자동 관리됨.

2. autoSetThumbnailIfMissing() 로직 개선

alive photos 리스트 생성

coverPhotoUrl이 alive photo 중 하나와 매칭되는지 검증

매칭되지 않으면 coverPhotoUrl 제거 → pickAutoThumbnailUrl()로 자동 선택

람다에서 사용되는 coverUrl을 final로 변경하여 컴파일 오류 해결

3. S3 삭제 안정화

PhotoServiceImpl.delete() → storage.delete() → S3PhotoStorage.delete()

삭제된 사진의 imageUrl / thumbnailUrl에서 S3 key 추출 정확성 개선

S3 삭제 실패 시 서비스 전체 장애 방지를 위한 WARN 로깅 유지

정상 삭제 시 [S3] deleted file= 로그가 출력되도록 설정

S3 삭제는 이미 문제없이 동작함을 확인.

🔍 수정 전 문제

DB에서는 photo.deleted = true 상태가 되지만
coverPhotoUrl이 해당 사진의 URL이면 그대로 남음

사용자는 썸네일이 안 바뀌어 “사진이 안 없어짐”으로 보임

공유 앨범에서도 동일한 문제 발생 가능

✔ 수정 후 기대 효과

사진 삭제 → 커버 자동 초기화 → 살아있는 사진 중 하나로 자동 대체

빈 앨범이면 썸네일 완전히 제거

S3 삭제도 함께 정확하게 이루어짐

UI에서 더 이상 삭제된 사진이 썸네일로 보이지 않음

🧪 테스트 범위

단일 사진 삭제

여러 사진 삭제

썸네일 사진 삭제

앨범 내 모든 사진 삭제

공유 앨범에서 사진 삭제

S3에 업로드된 실제 파일 삭제 여부