### PR TITLE
feat(map): 포토부스 자동완성 검색 API 추가

### DIFF
--- a/backend/src/main/java/com/nemo/backend/domain/map/controller/PhotoboothController.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/controller/PhotoboothController.java
@@ -126,6 +126,61 @@ public class PhotoboothController {
     }
 
     /**
+     * 🔍 포토부스 자동완성 검색 API
+     *
+     * - 사진 상세정보 입력창에서 위치 입력할 때 사용
+     * - 예시:
+     *   GET /api/map/photobooths/search?keyword=인생네컷%20수유&lat=37.6381&lng=127.0263&limit=10
+     */
+    @GetMapping("/search")
+    @Operation(
+            summary = "포토부스 자동완성 검색",
+            description = """
+                    사용자가 위치 입력창에 키워드를 입력했을 때,
+                    해당 키워드와 관련된 포토부스 지점 목록을 반환합니다.
+
+                    ✅ 사용 예시
+                    - keyword=명동          → 명동 근처 포토부스들
+                    - keyword=인생네컷       → 인생네컷 지점들
+                    - keyword=인생네컷 수유   → 인생네컷 수유점 근처 우선
+
+                    ✅ 권장 테스트 예시
+                    GET /api/map/photobooths/search?keyword=인생네컷%20수유&lat=37.6381&lng=127.0263&limit=10
+                    """
+    )
+    public ResponseEntity<List<PhotoboothDto>> searchPhotobooths(
+            @Parameter(
+                    description = "검색 키워드 (지점명/지역명/브랜드명 혼합 가능)",
+                    example = "인생네컷 수유"
+            )
+            @RequestParam String keyword,
+
+            @Parameter(
+                    description = "현재 사용자 위도 (있으면 거리순 정렬에 사용)",
+                    example = "37.6381"
+            )
+            @RequestParam(required = false) Double lat,
+
+            @Parameter(
+                    description = "현재 사용자 경도 (있으면 거리순 정렬에 사용)",
+                    example = "127.0263"
+            )
+            @RequestParam(required = false) Double lng,
+
+            @Parameter(
+                    description = "최대 반환 개수 (기본값 10)",
+                    example = "10"
+            )
+            @RequestParam(required = false, defaultValue = "10") Integer limit
+    ) {
+        List<PhotoboothDto> results =
+                service.searchPhotobooths(keyword, lat, lng, limit);
+
+        return ResponseEntity.ok(results);
+    }
+
+
+    /**
      * 뷰포트 유효성 검증 헬퍼 메서드
      * - 기존 /viewport GET에서도 재사용 중일 가능성 높음
      * - 여기서는 간단히 "상식적인 범위"만 거른다.

--- a/backend/src/main/java/com/nemo/backend/domain/map/service/PhotoboothService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/service/PhotoboothService.java
@@ -220,6 +220,39 @@ public class PhotoboothService {
 
         log.info("[MAP][SEARCH][RAW] totalRawItems={}", raw.size());
 
+        /**
+         * 🔁 Fallback: 지역명 붙인 검색에서 0개 나오면
+         *    → regionName 없이 한 번 더 검색
+         */
+        if (raw.isEmpty() && regionName != null && !regionName.isBlank()) {
+            log.info("[MAP][SEARCH][FALLBACK] no result with region. retry without region");
+
+            List<String> fallbackKeywords = new ArrayList<>();
+
+            if (containsBrand) {
+                // 예: "인생네컷 수유"
+                fallbackKeywords.add(trimmed);  // "인생네컷 수유"
+            } else {
+                // 예: "수유"
+                for (String brand : BRANDS) {
+                    fallbackKeywords.add(trimmed + " " + brand);  // "수유 인생네컷" ...
+                }
+                fallbackKeywords.add(trimmed + " 포토부스");        // "수유 포토부스"
+            }
+
+            for (String kw : fallbackKeywords) {
+                Map<String, Object> res = naverApiClient.searchLocal(kw, PAGE_SIZE, 1, "random");
+                List<Map<String, Object>> items = extractItems(res);
+                raw.addAll(items);
+
+                if (raw.size() >= max * 2) {
+                    break;
+                }
+            }
+
+            log.info("[MAP][SEARCH][RAW][FALLBACK] totalRawItems={}", raw.size());
+        }
+
         // ────────────────────────────────────────
         // 4) raw → PhotoboothDto 변환 + 좌표 없는 항목 제거
         // ────────────────────────────────────────

--- a/backend/src/main/java/com/nemo/backend/domain/map/service/PhotoboothService.java
+++ b/backend/src/main/java/com/nemo/backend/domain/map/service/PhotoboothService.java
@@ -37,7 +37,12 @@ public class PhotoboothService {
 
     // 🔍 기본 검색 키워드(브랜드 + 일반 키워드)
     private static final List<String> KEYWORDS = List.of(
-            "포토부스", "인생네컷", "하루필름", "포토이즘", "포토시그널", "포토그레이", "돈룩업"
+            "포토부스", "인생네컷", "하루필름", "포토이즘", "포토시그널", "포토그레이", "돈룩업", "엑시트", "포토랩"
+    );
+
+    // 포토부스 브랜드 이름만 모아둔 리스트 (자동완성 검색용)
+    private static final List<String> BRANDS = List.of(
+            "포토부스", "인생네컷", "하루필름", "포토이즘", "포토시그널", "포토그레이", "돈룩업", "엑시트", "포토랩"
     );
 
     private static final int PAGE_SIZE = 5;               // 네이버 LocalSearch 최대 display=5
@@ -135,6 +140,136 @@ public class PhotoboothService {
         // v.setZoom( ... ) // 필요하면 추후 추가
         return v;
     }
+
+    /**
+     * 🔍 포토부스 자동완성 검색
+     *
+     * - keyword: "명동", "인생네컷", "인생네컷 수유" 등
+     * - lat/lng 이 있으면 현재 위치 기준으로 distanceMeter 계산 후 가까운 순 정렬
+     * - 브랜드명 + 지점명을 같이 쳐도 동작하도록 키워드 조합
+     */
+    public List<PhotoboothDto> searchPhotobooths(
+            String keyword,
+            Double lat,
+            Double lng,
+            Integer limit
+    ) {
+        if (keyword == null || keyword.isBlank()) {
+            return List.of();
+        }
+
+        String trimmed = keyword.trim();
+        int max = (limit != null && limit > 0) ? limit : 10;
+
+        // ────────────────────────────────────────
+        // 1) (선택) 현재 위치 기준으로 regionName 얻기
+        // ────────────────────────────────────────
+        String regionName = null;
+        if (lat != null && lng != null) {
+            regionName = naverApiClient.reverseGeocodeToRegion(lat, lng)
+                    .orElse(null);
+        }
+
+        // ────────────────────────────────────────
+        // 2) 실제 네이버에 던질 검색 키워드 조합
+        //    - 브랜드명이 포함된 검색어인지 먼저 판단
+        // ────────────────────────────────────────
+        List<String> searchKeywords = new ArrayList<>();
+
+        boolean containsBrand = !Objects.equals(guessBrand(trimmed), "기타");
+
+        if (containsBrand) {
+            // 예: "인생네컷 수유"
+            if (regionName != null && !regionName.isBlank()) {
+                searchKeywords.add(regionName + " " + trimmed);
+            }
+            searchKeywords.add(trimmed);
+        } else {
+            // 예: "명동"
+            String base = trimmed;
+            if (regionName != null && !regionName.isBlank()) {
+                base = regionName + " " + trimmed;
+            }
+
+            // "명동 인생네컷", "명동 포토그레이" ...
+            for (String brand : BRANDS) {
+                searchKeywords.add(base + " " + brand);
+            }
+            // "명동 포토부스"
+            searchKeywords.add(base + " 포토부스");
+        }
+
+        log.info("[MAP][SEARCH] keyword='{}', region='{}', searchKeywords={}",
+                trimmed, regionName, searchKeywords);
+
+        // ────────────────────────────────────────
+        // 3) 네이버 LocalSearch 여러 번 호출해서 raw 결과 수집
+        // ────────────────────────────────────────
+        List<Map<String, Object>> raw = new ArrayList<>();
+
+        for (String kw : searchKeywords) {
+            Map<String, Object> res = naverApiClient.searchLocal(kw, PAGE_SIZE, 1, "random");
+            List<Map<String, Object>> items = extractItems(res);
+            raw.addAll(items);
+
+            // 너무 많이 모이면 조기 종료 (성능 보호)
+            if (raw.size() >= max * 2) {
+                break;
+            }
+        }
+
+        log.info("[MAP][SEARCH][RAW] totalRawItems={}", raw.size());
+
+        // ────────────────────────────────────────
+        // 4) raw → PhotoboothDto 변환 + 좌표 없는 항목 제거
+        // ────────────────────────────────────────
+        List<PhotoboothDto> all = raw.stream()
+                .map(this::toDto)  // 이미 존재하는 헬퍼 메서드
+                .filter(dto -> dto.getLatitude() != 0 && dto.getLongitude() != 0)
+                .toList();
+
+        // ────────────────────────────────────────
+        // 5) 중복 제거 (50m 이내 + 이름 유사)
+        //    viewport 로직과 동일한 기준 사용
+        // ────────────────────────────────────────
+        List<PhotoboothDto> deduped = new ArrayList<>();
+        for (PhotoboothDto cur : all) {
+            boolean dup = deduped.stream().anyMatch(x ->
+                    distanceMeter(x.getLatitude(), x.getLongitude(),
+                            cur.getLatitude(), cur.getLongitude()) < 50 &&
+                            (core(x.getName()).contains(core(cur.getName())) ||
+                                    core(cur.getName()).contains(core(x.getName())))
+            );
+            if (!dup) {
+                deduped.add(cur);
+            }
+        }
+
+        log.info("[MAP][SEARCH][DEDUP] deduped={}", deduped.size());
+
+        // ────────────────────────────────────────
+        // 6) 거리 계산 & 정렬 (lat/lng 있을 때만)
+        // ────────────────────────────────────────
+        if (lat != null && lng != null) {
+            for (PhotoboothDto dto : deduped) {
+                dto.setDistanceMeter(
+                        distanceMeter(lat, lng, dto.getLatitude(), dto.getLongitude())
+                );
+            }
+            deduped.sort(Comparator.comparingInt(PhotoboothDto::getDistanceMeter));
+        }
+
+        // ────────────────────────────────────────
+        // 7) limit 만큼 자르기
+        // ────────────────────────────────────────
+        if (deduped.size() > max) {
+            deduped = deduped.subList(0, max);
+        }
+
+        log.info("[MAP][SEARCH][RETURN] finalCount={}", deduped.size());
+        return deduped;
+    }
+
 
     /**
      * 마커가 sinceTs 이후로 변경되었는지 여부를 판단하는 헬퍼.


### PR DESCRIPTION


# ✅ 제목

**feat(map): 포토부스 자동완성 검색 API 추가 (사진 위치 입력 지원)**

---

# ✅ 내용 

## 🔍 포토부스 자동완성 검색 API 추가

사진 업로드/수정 화면에서 **위치 입력 시 자동완성 리스트**가 뜨도록
포토부스 검색 전용 API를 신규로 추가했습니다.

기존 지도 기능(뷰포트 기반 마커 검색)과 별개로,
**키워드를 입력받아 즉시 검색하는 방식**입니다.

---

## ✨ 추가된 기능 요약

### ✔ 새로운 API

**`GET /api/map/photobooths/search`**

### ✔ 지원되는 검색 방식

* 지역명 입력 → `명동` → 명동 주변 포토부스 탐색
* 브랜드명 입력 → `인생네컷` → 전국 인생네컷 지점 탐색
* 지점명 입력 → `인생네컷 수유` → 해당 지점 우선 반환
* 위도/경도 전달 시 → 현재 위치 기준 거리순 정렬
* 중복 제거 기준 → 50m + 이름 유사도 (기존 지도 로직 동일)

### ✔ 응답 예시

```json
[
  {
    "placeId": "n123abc",
    "name": "인생네컷 수유점",
    "brand": "인생네컷",
    "latitude": 37.63812,
    "longitude": 127.02631,
    "roadAddress": "서울 강북구 도봉로 10길 12",
    "distanceMeter": 120
  }
]
```

---

## 🧪 Swagger 테스트 방법

Swagger → **지도(Map)** → **포토부스 자동완성 검색** 선택 후
아래 파라미터 입력하면 바로 테스트 가능합니다.

```
keyword = 인생네컷 수유
lat     = 37.6381
lng     = 127.0263
limit   = 10
```

---

## 🛠 변경된 파일

* `PhotoboothController`

    * `/search` 엔드포인트 추가
    * Swagger 문서화 추가

* `PhotoboothService`

    * `searchPhotobooths()` 신규 메서드 구현
    * 키워드 조합 / 중복 제거 / 거리 정렬 로직 포함

* `NaverApiClient`

    * 수정 없음 (기존 Local Search / Reverse Geocode 재사용)

---

## 🎯 기대 효과

* 사진 업로드 UX 개선 → 위치 입력 속도 & 정확도 향상
* 브랜드 자동 선택 가능
* 지도 기능과 동일한 품질 기준 유지
* 프론트에서 복잡한 검색 로직 없이 API만 호출하면 됨

---